### PR TITLE
Replace lib-ui useSelectionState with a batteries implementation, fix related quirks, handle shift+click multiselect and bulk selection

### DIFF
--- a/packages/module/patternfly-docs/content/examples/ExampleAdvancedCaching.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleAdvancedCaching.tsx
@@ -161,19 +161,7 @@ export const ExampleAdvancedCaching: React.FunctionComponent = () => {
     isLoading: isLoadingMockData,
     currentPageItems: mockFetchResponse?.data || [],
     totalItemCount: mockFetchResponse?.totalItemCount || 0,
-    // TODO this shouldn't be necessary once we refactor useSelectionState to fit the rest of the table-batteries pattern.
-    // Due to an unresolved issue, the `selectionState` is required here even though we're not using selection.
-    // As a temporary workaround we pass stub values for these properties.
-    selectionState: {
-      selectedItems: [],
-      isItemSelected: () => false,
-      isItemSelectable: () => false,
-      toggleItemSelected: () => {},
-      selectMultiple: () => {},
-      areAllSelected: false,
-      selectAll: () => {},
-      setSelectedItems: () => {}
-    }
+    variant: 'compact'
   });
 
   // Everything below is the same as in the basic client-side example!

--- a/packages/module/patternfly-docs/content/examples/ExampleAdvancedPersistTargets.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleAdvancedPersistTargets.tsx
@@ -94,7 +94,8 @@ export const ExampleAdvancedPersistTargets: React.FunctionComponent = () => {
       description: thing.description || ''
     }),
     initialSort: { columnKey: 'name', direction: 'asc' },
-    isLoading: isLoadingMockData
+    isLoading: isLoadingMockData,
+    variant: 'compact'
   });
 
   // Here we destructure some of the properties from `tableBatteries` for rendering.

--- a/packages/module/patternfly-docs/content/examples/ExampleBasicClientPaginated.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleBasicClientPaginated.tsx
@@ -90,7 +90,8 @@ export const ExampleBasicClientPaginated: React.FunctionComponent = () => {
       description: thing.description || ''
     }),
     initialSort: { columnKey: 'name', direction: 'asc' },
-    isLoading: isLoadingMockData
+    isLoading: isLoadingMockData,
+    variant: 'compact'
   });
 
   // Here we destructure some of the properties from `tableBatteries` for rendering.

--- a/packages/module/patternfly-docs/content/examples/ExampleBasicServerPaginated.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleBasicServerPaginated.tsx
@@ -136,19 +136,7 @@ export const ExampleBasicServerPaginated: React.FunctionComponent = () => {
     isLoading: isLoadingMockData,
     currentPageItems: mockApiResponse.data,
     totalItemCount: mockApiResponse.totalItemCount,
-    // TODO this shouldn't be necessary once we refactor useSelectionState to fit the rest of the table-batteries pattern.
-    // Due to an unresolved issue, the `selectionState` is required here even though we're not using selection.
-    // As a temporary workaround we pass stub values for these properties.
-    selectionState: {
-      selectedItems: [],
-      isItemSelected: () => false,
-      isItemSelectable: () => false,
-      toggleItemSelected: () => {},
-      selectMultiple: () => {},
-      areAllSelected: false,
-      selectAll: () => {},
-      setSelectedItems: () => {}
-    }
+    variant: 'compact'
   });
 
   // Everything below is the same as in the basic client-side example!

--- a/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
@@ -1,9 +1,174 @@
 import React from 'react';
-import { ExtendedButton } from '@patternfly-labs/react-table-batteries';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  Pagination
+} from '@patternfly/react-core';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import {
+  useClientTableBatteries,
+  TableHeaderContentWithBatteries,
+  ConditionalTableBody,
+  TableRowContentWithBatteries,
+  FilterToolbar,
+  FilterType,
+  ToolbarBulkSelector
+} from '@patternfly-labs/react-table-batteries';
 
-export const ExampleFeatureSelection: React.FunctionComponent = () => (
-  <>
-    Table stuff goes here!
-    <ExtendedButton>My custom extension button</ExtendedButton>
-  </>
-);
+// This example table's rows represent Thing objects in our fake API.
+interface Thing {
+  id: number;
+  name: string;
+  description: string;
+}
+
+// This is a barebones mock API server to demonstrate fetching data.
+// We use a timeout of 1000ms here to simulate the loading state when data is fetched.
+interface MockAPIResponse {
+  data: Thing[];
+}
+const fetchMockData = () =>
+  new Promise<MockAPIResponse>((resolve) => {
+    setTimeout(() => {
+      const mockData: Thing[] = [
+        { id: 1, name: 'Thing 01', description: 'Something from the API' },
+        { id: 2, name: 'Thing 02', description: 'Something else from the API' }
+      ];
+      resolve({ data: mockData });
+    }, 1000);
+  });
+
+export const ExampleFeatureSelection: React.FunctionComponent = () => {
+  // In a real table we'd use a real API fetch here, perhaps using a library like react-query.
+  const [mockApiResponse, setMockApiResponse] = React.useState<MockAPIResponse>({ data: [] });
+  const [isLoadingMockData, setIsLoadingMockData] = React.useState(false);
+  React.useEffect(() => {
+    setIsLoadingMockData(true);
+    fetchMockData().then((response) => {
+      setMockApiResponse(response);
+      setIsLoadingMockData(false);
+    });
+  }, []);
+
+  const tableBatteries = useClientTableBatteries({
+    persistTo: 'urlParams',
+    persistenceKeyPrefix: 't1', // The first Things table on this page.
+    idProperty: 'id', // The name of a unique string or number property on the data items.
+    items: mockApiResponse.data, // The generic type `TItem` is inferred from the items passed here.
+    columnNames: {
+      // The keys of this object define the inferred generic type `TColumnKey`. See "Unique Identifiers".
+      name: 'Name',
+      description: 'Description'
+    },
+    isFilterEnabled: true,
+    isSortEnabled: true,
+    isPaginationEnabled: true,
+    isSelectionEnabled: true,
+    // Because isFilterEnabled is true, TypeScript will require these filterCategories:
+    filterCategories: [
+      {
+        key: 'name',
+        title: 'Name',
+        type: FilterType.search,
+        placeholderText: 'Filter by name...',
+        getItemValue: (thing) => thing.name || ''
+      },
+      {
+        key: 'description',
+        title: 'Description',
+        type: FilterType.search,
+        placeholderText: 'Filter by description...'
+      }
+    ],
+    // Because isSortEnabled is true, TypeScript will require these sort-related properties:
+    sortableColumns: ['name', 'description'],
+    getSortValues: (thing) => ({
+      name: thing.name || '',
+      description: thing.description || ''
+    }),
+    initialSort: { columnKey: 'name', direction: 'asc' },
+    isLoading: isLoadingMockData
+  });
+
+  // Here we destructure some of the properties from `tableBatteries` for rendering.
+  // Later we also spread the entire `tableBatteries` object onto components whose props include subsets of it.
+  const {
+    currentPageItems, // These items have already been paginated.
+    // `numRenderedColumns` is based on the number of columnNames and additional columns needed for
+    // rendering controls related to features like selection, expansion, etc.
+    // It is used as the colSpan when rendering a full-table-wide cell.
+    numRenderedColumns,
+    // The objects and functions in `propHelpers` correspond to the props needed for specific PatternFly or Tackle
+    // components and are provided to reduce prop-drilling and make the rendering code as short as possible.
+    propHelpers: {
+      toolbarProps,
+      toolbarBulkSelectorProps,
+      filterToolbarProps,
+      paginationToolbarItemProps,
+      paginationProps,
+      tableProps,
+      getThProps,
+      getTrProps,
+      getTdProps
+    }
+  } = tableBatteries;
+
+  return (
+    <>
+      <Toolbar {...toolbarProps}>
+        <ToolbarContent>
+          <ToolbarBulkSelector {...toolbarBulkSelectorProps} />
+          <FilterToolbar {...filterToolbarProps} id="client-paginated-example-filters" />
+          {/* You can render whatever other custom toolbar items you may need here! */}
+          <ToolbarItem {...paginationToolbarItemProps}>
+            <Pagination variant="top" isCompact {...paginationProps} widgetId="client-paginated-example-pagination" />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
+      <Table {...tableProps} aria-label="Example things table">
+        <Thead>
+          <Tr>
+            <TableHeaderContentWithBatteries {...tableBatteries}>
+              <Th {...getThProps({ columnKey: 'name' })} />
+              <Th {...getThProps({ columnKey: 'description' })} />
+            </TableHeaderContentWithBatteries>
+          </Tr>
+        </Thead>
+        <ConditionalTableBody
+          isLoading={isLoadingMockData}
+          isNoData={currentPageItems.length === 0}
+          noDataEmptyState={
+            <EmptyState variant="sm">
+              <EmptyStateIcon icon={CubesIcon} />
+              <Title headingLevel="h2" size="lg">
+                No things available
+              </Title>
+            </EmptyState>
+          }
+          numRenderedColumns={numRenderedColumns}
+        >
+          <Tbody>
+            {currentPageItems?.map((thing, rowIndex) => (
+              <Tr key={thing.id} {...getTrProps({ item: thing })}>
+                <TableRowContentWithBatteries {...tableBatteries} item={thing} rowIndex={rowIndex}>
+                  <Td width={30} {...getTdProps({ columnKey: 'name' })}>
+                    {thing.name}
+                  </Td>
+                  <Td width={70} {...getTdProps({ columnKey: 'description' })}>
+                    {thing.description}
+                  </Td>
+                </TableRowContentWithBatteries>
+              </Tr>
+            ))}
+          </Tbody>
+        </ConditionalTableBody>
+      </Table>
+      <Pagination variant="bottom" isCompact {...paginationProps} widgetId="client-paginated-example-pagination" />
+    </>
+  );
+};

--- a/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
@@ -37,7 +37,17 @@ const fetchMockData = () =>
     setTimeout(() => {
       const mockData: Thing[] = [
         { id: 1, name: 'Thing 01', description: 'Something from the API' },
-        { id: 2, name: 'Thing 02', description: 'Something else from the API' }
+        { id: 2, name: 'Thing 02', description: 'Something else from the API' },
+        { id: 3, name: 'Thing 03', description: 'Another API object' },
+        { id: 4, name: 'Thing 04', description: 'We have more than 10 things here' },
+        { id: 5, name: 'Thing 05', description: 'So you can try the "select page" behavior' },
+        { id: 6, name: 'Thing 06', description: 'These all need descriptions' },
+        { id: 7, name: 'Thing 07', description: 'But there is nothing else to say' },
+        { id: 8, name: 'Thing 08', description: "I hope you're enjoying these examples" },
+        { id: 9, name: 'Thing 09', description: 'Some pretty cool stuff if I do say so myself' },
+        { id: 10, name: 'Thing 10', description: 'See you later' },
+        { id: 11, name: 'Thing 11', description: 'Oh hey you made it to page 2' },
+        { id: 12, name: 'Thing 12', description: 'Nice work' }
       ];
       resolve({ data: mockData });
     }, 1000);
@@ -92,7 +102,8 @@ export const ExampleFeatureSelection: React.FunctionComponent = () => {
       description: thing.description || ''
     }),
     initialSort: { columnKey: 'name', direction: 'asc' },
-    isLoading: isLoadingMockData
+    isLoading: isLoadingMockData,
+    variant: 'compact'
   });
 
   // Here we destructure some of the properties from `tableBatteries` for rendering.

--- a/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
@@ -38,7 +38,7 @@ const fetchMockData = () =>
       const mockData: Thing[] = [
         { id: 1, name: 'Thing 01', description: 'Something from the API' },
         { id: 2, name: 'Thing 02', description: 'Something else from the API' },
-        { id: 3, name: 'Thing 03', description: 'Another API object' },
+        { id: 3, name: 'Thing 03', description: 'Another API object. This one is not selectable!' },
         { id: 4, name: 'Thing 04', description: 'We have more than 10 things here' },
         { id: 5, name: 'Thing 05', description: 'So you can try the "select page" behavior' },
         { id: 6, name: 'Thing 06', description: 'These all need descriptions' },

--- a/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
@@ -115,8 +115,12 @@ export const ExampleFeatureSelection: React.FunctionComponent = () => {
       getThProps,
       getTrProps,
       getTdProps
-    }
+    },
+    selectionDerivedState: { selectedItems }
   } = tableBatteries;
+
+  // eslint-disable-next-line no-console
+  console.log('Do something with selected items:', selectedItems);
 
   return (
     <>

--- a/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
+++ b/packages/module/patternfly-docs/content/examples/ExampleFeatureSelection.tsx
@@ -102,6 +102,7 @@ export const ExampleFeatureSelection: React.FunctionComponent = () => {
       description: thing.description || ''
     }),
     initialSort: { columnKey: 'name', direction: 'asc' },
+    isItemSelectable: (item) => item.id !== 3, // Testing the non-selectable item behavior
     isLoading: isLoadingMockData,
     variant: 'compact'
   });

--- a/packages/module/patternfly-docs/content/examples/basic.md
+++ b/packages/module/patternfly-docs/content/examples/basic.md
@@ -209,11 +209,7 @@ TODO copy over and rework things from OLD_DOCS.md here
 
 ### Selection
 
-TODO this example will come in a separate PR
-
-TODO add a version of the basic client table example with only selection enabled
-
-TODO copy over and rework things from OLD_DOCS.md here
+TODO copy over and rework notes from OLD_DOCS.md here
 
 ```js file="./ExampleFeatureSelection.tsx"
 

--- a/packages/module/patternfly-docs/content/examples/basic.md
+++ b/packages/module/patternfly-docs/content/examples/basic.md
@@ -131,7 +131,7 @@ The easiest way to achieve this caching behavior is to use a data fetching libra
 
 TODO this example will come in a separate PR
 
-TODO don't use useTableState, but use getClientTableDerivedState
+TODO don't use useTableState, but use useClientTableDerivedState
 
 TODO remark on how this may be helpful for incremental adoption
 
@@ -159,7 +159,7 @@ TODO this example will come in a separate PR
 
 TODO remark on how all the state management and built-in logic provided by `useTableState` and `useClientTableBatteries` is optional, and if you want your table to handle all its own business logic you can still benefit from useTablePropHelpers to make rendering easier.
 
-TODO remark on how this may be helpful as the first step in incremental adoption, followed by adopting `useTableState` and then maybe `getClientTableDerivedState` or the full `useClientTableBatteries` (as in the [basic client-side example](#client-side-filteringsortingpagination)).
+TODO remark on how this may be helpful as the first step in incremental adoption, followed by adopting `useTableState` and then maybe `useClientTableDerivedState` or the full `useClientTableBatteries` (as in the [basic client-side example](#client-side-filteringsortingpagination)).
 
 ```js file="./ExampleAdvancedBYOStateAndLogic.tsx"
 
@@ -286,7 +286,7 @@ If your API does not support these parameters or you need to have the entire col
 In most cases, you'll only need to use these higher-level hooks and helpers to build a table:
 
 - For client-paginated tables: `useClientTableBatteries` is all you need.
-  - Internally it uses `useTableState`, `useTablePropHelpers` and the `getClientTableDerivedState` helper. The config arguments object is a combination of the arguments required by `useTableState` and `useTablePropHelpers`.
+  - Internally it uses `useTableState`, `useTablePropHelpers` and the `useClientTableDerivedState` helper. The config arguments object is a combination of the arguments required by `useTableState` and `useTablePropHelpers`.
   - The return value (an object we generally name `tableBatteries`) has everything you need to render your table. Give it a `console.log` to see what is available.
 - For server-paginated tables: `useTableState`, `getHubRequestParams`, and `useTablePropHelpers`.
   - Choose whether you want to use React state (default), URL params (recommended), localStorage or sessionStorage as the source of truth, and call `useTableState` with the appropriate `persistTo` option and optional `persistenceKeyPrefix` (to namespace persisted state for multiple tables on the same page).

--- a/packages/module/patternfly-docs/content/examples/basic.md
+++ b/packages/module/patternfly-docs/content/examples/basic.md
@@ -35,6 +35,7 @@ import {
 useClientTableBatteries,
 useTablePropHelpers,
 useTableState,
+ToolbarBulkSelector,
 TableHeaderContentWithBatteries,
 ConditionalTableBody,
 TableRowContentWithBatteries,

--- a/packages/module/src/OLD_DOCS.md
+++ b/packages/module/src/OLD_DOCS.md
@@ -181,7 +181,7 @@ Items are filtered according to user-selected filter key/value pairs.
 
 - Keys and filter types (search, select, etc) are defined by the `filterCategories` array config argument. The `key` properties of each of these `FilterCategory` objects are the source of truth for the inferred generic type `TFilterCategoryKeys` (For more, see the JSDoc comments in the `types.ts` file).
 - Filter state is provided by `useFilterState`.
-- For client-side filtering, the filter logic is provided by `getClientFilterDerivedState` (based on the `getItemValue` callback defined on each `FilterCategory` object, which is not required when using server-side filtering).
+- For client-side filtering, the filter logic is provided by `useClientFilterDerivedState` (based on the `getItemValue` callback defined on each `FilterCategory` object, which is not required when using server-side filtering).
 - For server-side filtering, filter state is serialized for the API by `getFilterHubRequestParams`.
 - Filter-related component props are provided by `useFilterPropHelpers`.
 - Filter inputs and chips are rendered by the `FilterToolbar` component.
@@ -194,7 +194,7 @@ Items are sorted according to the user-selected sort column and direction.
 
 - Sortable columns are defined by a `sortableColumns` array of `TColumnKey` values (see [Unique Identifiers](#unique-identifiers)).
 - Sort state is provided by `useSortState`.
-- For client-side sorting, the sort logic is provided by `getClientSortDerivedState` (based on the `getSortValues` config argument, which is not required when using server-side sorting).
+- For client-side sorting, the sort logic is provided by `useClientSortDerivedState` (based on the `getSortValues` config argument, which is not required when using server-side sorting).
 - For server-side sorting, sort state is serialized for the API by `getSortHubRequestParams`.
 - Sort-related component props are provided by `useSortPropHelpers`.
 - Sort inputs are rendered by the table's `Th` PatternFly component.
@@ -205,7 +205,7 @@ Items are paginated according to the user-selected page number and items-per-pag
 
 - The only config argument for pagination is the optional `initialItemsPerPage` which defaults to 10.
 - Pagination state is provided by `usePaginationState`.
-- For client-side pagination, the pagination logic is provided by `getClientPaginationDerivedState`.
+- For client-side pagination, the pagination logic is provided by `useClientPaginationDerivedState`.
 - For server-side pagination, pagination state is serialized for the API by `getPaginationHubRequestParams`.
 - Pagination-related component props are provided by `usePaginationPropHelpers`.
 - A `useEffect` call which prevents invalid state after an item is deleted is provided by `usePaginationEffects`. This is called internally by `usePaginationPropHelpers`.
@@ -221,7 +221,7 @@ Item details can be expanded, either with a "single expansion" variant where an 
 
 - Single or compound expansion is defined by the optional `expandableVariant` config argument which defaults to `"single"`.
 - Expansion state is provided by `useExpansionState`.
-- Expansion shorthand functions are provided by `getExpansionDerivedState`.
+- Expansion shorthand functions are provided by `useExpansionDerivedState`.
 - Expansion is never managed server-side.
 - Expansion-related component props are provided by `useExpansionPropHelpers`.
 - Expansion inputs are rendered by the table's `Td` PatternFly component and expanded content is managed at the consumer level by conditionally rendering a second row with full colSpan inside a PatternFly `Tbody` component. The `numRenderedColumns` value returned by `useTablePropHelpers` can be used for the correct colSpan here.
@@ -232,7 +232,7 @@ A row can be clicked to mark its item as "active", which usually opens a drawer 
 
 - The active item feature requires no config arguments.
 - Active item state is provided by `useActiveItemState`.
-- Active item shorthand functions are provided by `getActiveItemDerivedState`.
+- Active item shorthand functions are provided by `useActiveItemDerivedState`.
 - Active-item-related component props are provided by `useActiveItemPropHelpers`.
 - A `useEffect` call which prevents invalid state after an item is deleted is provided by `useActiveItemEffects`. This is called internally in `useActiveItemPropHelpers`.
 

--- a/packages/module/src/hooks/active-item/getActiveItemDerivedState.ts
+++ b/packages/module/src/hooks/active-item/getActiveItemDerivedState.ts
@@ -1,4 +1,5 @@
 import { KeyWithValueType } from '../../type-utils';
+import { ItemId } from '../../types';
 import { ActiveItemState } from './useActiveItemState';
 
 /**
@@ -63,7 +64,7 @@ export const getActiveItemDerivedState = <TItem>({
 }: GetActiveItemDerivedStateArgs<TItem>): ActiveItemDerivedState<TItem> => ({
   activeItem: currentPageItems.find((item) => item[idProperty] === activeItemId) || null,
   setActiveItem: (item: TItem | null) => {
-    const itemId = (item?.[idProperty] ?? null) as string | number | null; // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?
+    const itemId = (item?.[idProperty] ?? null) as ItemId | null; // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?
     setActiveItemId(itemId);
   },
   clearActiveItem: () => setActiveItemId(null),

--- a/packages/module/src/hooks/active-item/getActiveItemDerivedState.ts
+++ b/packages/module/src/hooks/active-item/getActiveItemDerivedState.ts
@@ -17,7 +17,7 @@ export interface GetActiveItemDerivedStateArgs<TItem> {
   /**
    * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
    */
-  idProperty: KeyWithValueType<TItem, string | number>;
+  idProperty: KeyWithValueType<TItem, ItemId>;
   /**
    * The "source of truth" state for the active item feature (returned by useActiveItemState)
    */

--- a/packages/module/src/hooks/active-item/index.ts
+++ b/packages/module/src/hooks/active-item/index.ts
@@ -1,4 +1,4 @@
 export * from './useActiveItemState';
-export * from './getActiveItemDerivedState';
+export * from './useActiveItemDerivedState';
 export * from './useActiveItemPropHelpers';
 export * from './useActiveItemEffects';

--- a/packages/module/src/hooks/active-item/useActiveItemDerivedState.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemDerivedState.ts
@@ -3,13 +3,13 @@ import { ItemId } from '../../types';
 import { ActiveItemState } from './useActiveItemState';
 
 /**
- * Args for getActiveItemDerivedState
+ * Args for useActiveItemDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
  * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export interface GetActiveItemDerivedStateArgs<TItem> {
+export interface UseActiveItemDerivedStateArgs<TItem> {
   /**
    * The current page of API data items after filtering/sorting/pagination
    */
@@ -53,15 +53,15 @@ export interface ActiveItemDerivedState<TItem> {
  * Given the "source of truth" state for the active item feature and additional arguments, returns "derived state" values and convenience functions.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  *
- * NOTE: Unlike `getClient[Filter|Sort|Pagination]DerivedState`, this is not named `getClientActiveItemDerivedState` because it
+ * NOTE: Unlike `useClient[Filter|Sort|Pagination]DerivedState`, this is not named `useClientActiveItemDerivedState` because it
  * is always local/client-computed, and it is still used when working with server-computed tables
- * (it's not specific to client-only-computed tables like the other `getClient*DerivedState` functions are).
+ * (it's not specific to client-only-computed tables like the other `useClient*DerivedState` functions are).
  */
-export const getActiveItemDerivedState = <TItem>({
+export const useActiveItemDerivedState = <TItem>({
   currentPageItems,
   idProperty,
   activeItemState: { activeItemId, setActiveItemId }
-}: GetActiveItemDerivedStateArgs<TItem>): ActiveItemDerivedState<TItem> => ({
+}: UseActiveItemDerivedStateArgs<TItem>): ActiveItemDerivedState<TItem> => ({
   activeItem: currentPageItems.find((item) => item[idProperty] === activeItemId) || null,
   setActiveItem: (item: TItem | null) => {
     const itemId = (item?.[idProperty] ?? null) as ItemId | null; // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?

--- a/packages/module/src/hooks/active-item/useActiveItemDerivedState.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemDerivedState.ts
@@ -1,6 +1,5 @@
 import { KeyWithValueType } from '../../type-utils';
 import { ItemId } from '../../types';
-import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemEffects';
 import { ActiveItemState } from './useActiveItemState';
 
 /**
@@ -10,7 +9,7 @@ import { ActiveItemState } from './useActiveItemState';
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export type UseActiveItemDerivedStateArgs<TItem> = Omit<UseActiveItemEffectsArgs<TItem>, 'activeItemDerivedState'> & {
+export interface UseActiveItemDerivedStateArgs<TItem> {
   /**
    * The current page of API data items after filtering/sorting/pagination
    */
@@ -23,7 +22,7 @@ export type UseActiveItemDerivedStateArgs<TItem> = Omit<UseActiveItemEffectsArgs
    * The "source of truth" state for the active item feature (returned by useActiveItemState)
    */
   activeItemState: ActiveItemState;
-};
+}
 
 /**
  * Derived state for the active item feature
@@ -53,29 +52,21 @@ export interface ActiveItemDerivedState<TItem> {
 /**
  * Given the "source of truth" state for the active item feature and additional arguments, returns "derived state" values and convenience functions.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
- * - Also triggers side effects to prevent invalid state
  *
  * NOTE: Unlike `useClient[Filter|Sort|Pagination]DerivedState`, this is not named `useClientActiveItemDerivedState` because it
  * is always local/client-computed, and it is still used when working with server-computed tables
  * (it's not specific to client-only-computed tables like the other `useClient*DerivedState` functions are).
  */
-export const useActiveItemDerivedState = <TItem>(
-  args: UseActiveItemDerivedStateArgs<TItem>
-): ActiveItemDerivedState<TItem> => {
-  const {
-    currentPageItems,
-    idProperty,
-    activeItemState: { activeItemId, setActiveItemId }
-  } = args;
-  const activeItemDerivedState: ActiveItemDerivedState<TItem> = {
-    activeItem: currentPageItems.find((item) => item[idProperty] === activeItemId) || null,
-    setActiveItem: (item: TItem | null) => {
-      const itemId = (item?.[idProperty] ?? null) as ItemId | null; // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?
-      setActiveItemId(itemId);
-    },
-    clearActiveItem: () => setActiveItemId(null),
-    isActiveItem: (item) => item[idProperty] === activeItemId
-  };
-  useActiveItemEffects({ ...args, activeItemDerivedState });
-  return activeItemDerivedState;
-};
+export const useActiveItemDerivedState = <TItem>({
+  currentPageItems,
+  idProperty,
+  activeItemState: { activeItemId, setActiveItemId }
+}: UseActiveItemDerivedStateArgs<TItem>): ActiveItemDerivedState<TItem> => ({
+  activeItem: currentPageItems.find((item) => item[idProperty] === activeItemId) || null,
+  setActiveItem: (item: TItem | null) => {
+    const itemId = (item?.[idProperty] ?? null) as ItemId | null; // TODO Assertion shouldn't be necessary here but TS isn't fully inferring item[idProperty]?
+    setActiveItemId(itemId);
+  },
+  clearActiveItem: () => setActiveItemId(null),
+  isActiveItem: (item) => item[idProperty] === activeItemId
+});

--- a/packages/module/src/hooks/active-item/useActiveItemEffects.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemEffects.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActiveItemDerivedState } from './getActiveItemDerivedState';
+import { ActiveItemDerivedState } from './useActiveItemDerivedState';
 import { ActiveItemState } from './useActiveItemState';
 
 /**
@@ -17,7 +17,7 @@ export interface UseActiveItemEffectsArgs<TItem> {
    */
   activeItemState: ActiveItemState;
   /**
-   * The "derived state" for the active item feature (returned by getActiveItemDerivedState)
+   * The "derived state" for the active item feature (returned by useActiveItemDerivedState)
    */
   activeItemDerivedState: ActiveItemDerivedState<TItem>;
 }

--- a/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
@@ -1,5 +1,5 @@
 import { TrProps } from '@patternfly/react-table';
-import { GetActiveItemDerivedStateArgs, getActiveItemDerivedState } from './getActiveItemDerivedState';
+import { UseActiveItemDerivedStateArgs, useActiveItemDerivedState } from './useActiveItemDerivedState';
 import { ActiveItemState } from './useActiveItemState';
 import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemEffects';
 
@@ -10,7 +10,7 @@ import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemE
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export type UseActiveItemPropHelpersExternalArgs<TItem> = GetActiveItemDerivedStateArgs<TItem> &
+export type UseActiveItemPropHelpersExternalArgs<TItem> = UseActiveItemDerivedStateArgs<TItem> &
   Omit<UseActiveItemEffectsArgs<TItem>, 'activeItemDerivedState'> & {
     /**
      * Whether the table data is loading
@@ -30,7 +30,7 @@ export type UseActiveItemPropHelpersExternalArgs<TItem> = GetActiveItemDerivedSt
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
 export const useActiveItemPropHelpers = <TItem>(args: UseActiveItemPropHelpersExternalArgs<TItem>) => {
-  const activeItemDerivedState = getActiveItemDerivedState(args);
+  const activeItemDerivedState = useActiveItemDerivedState(args);
   const { isActiveItem, setActiveItem, clearActiveItem } = activeItemDerivedState;
 
   useActiveItemEffects({ ...args, activeItemDerivedState });

--- a/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
@@ -1,6 +1,7 @@
 import { TrProps } from '@patternfly/react-table';
 import { UseActiveItemDerivedStateArgs, useActiveItemDerivedState } from './useActiveItemDerivedState';
 import { ActiveItemState } from './useActiveItemState';
+import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemEffects';
 
 /**
  * Args for useActiveItemPropHelpers that come from outside useTablePropHelpers
@@ -9,26 +10,31 @@ import { ActiveItemState } from './useActiveItemState';
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export type UseActiveItemPropHelpersExternalArgs<TItem> = UseActiveItemDerivedStateArgs<TItem> & {
-  /**
-   * Whether the table data is loading
-   */
-  isLoading?: boolean;
-  /**
-   * The "source of truth" state for the active item feature (returned by useActiveItemState)
-   */
-  activeItemState: ActiveItemState;
-};
+export type UseActiveItemPropHelpersExternalArgs<TItem> = UseActiveItemDerivedStateArgs<TItem> &
+  Omit<UseActiveItemEffectsArgs<TItem>, 'activeItemDerivedState'> & {
+    /**
+     * Whether the table data is loading
+     */
+    isLoading?: boolean;
+    /**
+     * The "source of truth" state for the active item feature (returned by useActiveItemState)
+     */
+    activeItemState: ActiveItemState;
+  };
 
 /**
  * Given "source of truth" state for the active item feature, returns derived state and `propHelpers`.
  * - Used internally by useTablePropHelpers
+ * - Also triggers side effects to prevent invalid state
  * - "Derived state" here refers to values and convenience functions derived at render time.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
 export const useActiveItemPropHelpers = <TItem>(args: UseActiveItemPropHelpersExternalArgs<TItem>) => {
   const activeItemDerivedState = useActiveItemDerivedState(args);
   const { isActiveItem, setActiveItem, clearActiveItem } = activeItemDerivedState;
+
+  useActiveItemEffects({ ...args, activeItemDerivedState });
+
   /**
    * Returns props for a clickable Tr in a table with the active item feature enabled. Sets or clears the active item when clicked.
    */

--- a/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemPropHelpers.ts
@@ -1,7 +1,6 @@
 import { TrProps } from '@patternfly/react-table';
 import { UseActiveItemDerivedStateArgs, useActiveItemDerivedState } from './useActiveItemDerivedState';
 import { ActiveItemState } from './useActiveItemState';
-import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemEffects';
 
 /**
  * Args for useActiveItemPropHelpers that come from outside useTablePropHelpers
@@ -10,31 +9,26 @@ import { UseActiveItemEffectsArgs, useActiveItemEffects } from './useActiveItemE
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export type UseActiveItemPropHelpersExternalArgs<TItem> = UseActiveItemDerivedStateArgs<TItem> &
-  Omit<UseActiveItemEffectsArgs<TItem>, 'activeItemDerivedState'> & {
-    /**
-     * Whether the table data is loading
-     */
-    isLoading?: boolean;
-    /**
-     * The "source of truth" state for the active item feature (returned by useActiveItemState)
-     */
-    activeItemState: ActiveItemState;
-  };
+export type UseActiveItemPropHelpersExternalArgs<TItem> = UseActiveItemDerivedStateArgs<TItem> & {
+  /**
+   * Whether the table data is loading
+   */
+  isLoading?: boolean;
+  /**
+   * The "source of truth" state for the active item feature (returned by useActiveItemState)
+   */
+  activeItemState: ActiveItemState;
+};
 
 /**
  * Given "source of truth" state for the active item feature, returns derived state and `propHelpers`.
  * - Used internally by useTablePropHelpers
- * - Also triggers side effects to prevent invalid state
  * - "Derived state" here refers to values and convenience functions derived at render time.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
 export const useActiveItemPropHelpers = <TItem>(args: UseActiveItemPropHelpersExternalArgs<TItem>) => {
   const activeItemDerivedState = useActiveItemDerivedState(args);
   const { isActiveItem, setActiveItem, clearActiveItem } = activeItemDerivedState;
-
-  useActiveItemEffects({ ...args, activeItemDerivedState });
-
   /**
    * Returns props for a clickable Tr in a table with the active item feature enabled. Sets or clears the active item when clicked.
    */

--- a/packages/module/src/hooks/active-item/useActiveItemState.ts
+++ b/packages/module/src/hooks/active-item/useActiveItemState.ts
@@ -1,4 +1,4 @@
-import { FeaturePersistenceArgs } from '../../types';
+import { FeaturePersistenceArgs, ItemId } from '../../types';
 import { parseMaybeNumericString } from '../../utils';
 import { usePersistentState } from '../generic/usePersistentState';
 
@@ -13,11 +13,11 @@ export interface ActiveItemState {
   /**
    * The item id (string or number resolved from `item[idProperty]`) of the active item. Null if no item is active.
    */
-  activeItemId: string | number | null;
+  activeItemId: ItemId | null;
   /**
    * Updates the active item by id. Pass null to dismiss the active item.
    */
-  setActiveItemId: (id: string | number | null) => void;
+  setActiveItemId: (id: ItemId | null) => void;
 }
 
 /**
@@ -48,11 +48,7 @@ export const useActiveItemState = <TPersistenceKeyPrefix extends string = string
 
   // We won't need to pass the latter two type params here if TS adds support for partial inference.
   // See https://github.com/konveyor/tackle2-ui/issues/1456
-  const [activeItemId, setActiveItemId] = usePersistentState<
-    string | number | null,
-    TPersistenceKeyPrefix,
-    'activeItem'
-  >({
+  const [activeItemId, setActiveItemId] = usePersistentState<ItemId | null, TPersistenceKeyPrefix, 'activeItem'>({
     isEnabled: !!isActiveItemEnabled,
     defaultValue: null,
     persistenceKeyPrefix,

--- a/packages/module/src/hooks/expansion/getExpansionDerivedState.ts
+++ b/packages/module/src/hooks/expansion/getExpansionDerivedState.ts
@@ -1,4 +1,5 @@
 import { KeyWithValueType } from '../../type-utils';
+import { ItemId } from '../../types';
 import { ExpansionState } from './useExpansionState';
 
 /**
@@ -12,7 +13,7 @@ export interface GetExpansionDerivedStateArgs<TItem, TColumnKey extends string> 
   /**
    * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
    */
-  idProperty: KeyWithValueType<TItem, string | number>;
+  idProperty: KeyWithValueType<TItem, ItemId>;
   /**
    * The "source of truth" state for the expansion feature (returned by useExpansionState)
    */

--- a/packages/module/src/hooks/expansion/index.ts
+++ b/packages/module/src/hooks/expansion/index.ts
@@ -1,3 +1,3 @@
 export * from './useExpansionState';
-export * from './getExpansionDerivedState';
+export * from './useExpansionDerivedState';
 export * from './useExpansionPropHelpers';

--- a/packages/module/src/hooks/expansion/useExpansionDerivedState.ts
+++ b/packages/module/src/hooks/expansion/useExpansionDerivedState.ts
@@ -3,13 +3,13 @@ import { ItemId } from '../../types';
 import { ExpansionState } from './useExpansionState';
 
 /**
- * Args for getExpansionDerivedState
+ * Args for useExpansionDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
  * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export interface GetExpansionDerivedStateArgs<TItem, TColumnKey extends string> {
+export interface UseExpansionDerivedStateArgs<TItem, TColumnKey extends string> {
   /**
    * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
    */
@@ -44,14 +44,14 @@ export interface ExpansionDerivedState<TItem, TColumnKey extends string> {
  * Given the "source of truth" state for the expansion feature and additional arguments, returns "derived state" values and convenience functions.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  *
- * NOTE: Unlike `getClient[Filter|Sort|Pagination]DerivedState`, this is not named `getClientExpansionDerivedState` because it
+ * NOTE: Unlike `useClient[Filter|Sort|Pagination]DerivedState`, this is not named `useClientExpansionDerivedState` because it
  * is always local/client-computed, and it is still used when working with server-computed tables
- * (it's not specific to client-only-computed tables like the other `getClient*DerivedState` functions are).
+ * (it's not specific to client-only-computed tables like the other `useClient*DerivedState` functions are).
  */
-export const getExpansionDerivedState = <TItem, TColumnKey extends string>({
+export const useExpansionDerivedState = <TItem, TColumnKey extends string>({
   idProperty,
   expansionState: { expandedCells, setExpandedCells }
-}: GetExpansionDerivedStateArgs<TItem, TColumnKey>): ExpansionDerivedState<TItem, TColumnKey> => {
+}: UseExpansionDerivedStateArgs<TItem, TColumnKey>): ExpansionDerivedState<TItem, TColumnKey> => {
   const isCellExpanded = (item: TItem, columnKey?: TColumnKey) =>
     columnKey ? expandedCells[String(item[idProperty])] === columnKey : !!expandedCells[String(item[idProperty])];
 

--- a/packages/module/src/hooks/expansion/useExpansionPropHelpers.ts
+++ b/packages/module/src/hooks/expansion/useExpansionPropHelpers.ts
@@ -2,6 +2,7 @@ import { ExpansionState } from './useExpansionState';
 import { getExpansionDerivedState } from './getExpansionDerivedState';
 import { TdProps } from '@patternfly/react-table';
 import { KeyWithValueType } from '../../type-utils';
+import { ItemId } from '../../types';
 
 /**
  * Args for useExpansionPropHelpers that come from outside useTablePropHelpers
@@ -20,7 +21,7 @@ export interface UseExpansionPropHelpersExternalArgs<TItem, TColumnKey extends s
   /**
    * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
    */
-  idProperty: KeyWithValueType<TItem, string | number>;
+  idProperty: KeyWithValueType<TItem, ItemId>;
   /**
    * The "source of truth" state for the expansion feature (returned by useExpansionState)
    */

--- a/packages/module/src/hooks/expansion/useExpansionPropHelpers.ts
+++ b/packages/module/src/hooks/expansion/useExpansionPropHelpers.ts
@@ -1,5 +1,5 @@
 import { ExpansionState } from './useExpansionState';
-import { getExpansionDerivedState } from './getExpansionDerivedState';
+import { useExpansionDerivedState } from './useExpansionDerivedState';
 import { TdProps } from '@patternfly/react-table';
 import { KeyWithValueType } from '../../type-utils';
 import { ItemId } from '../../types';
@@ -62,7 +62,7 @@ export const useExpansionPropHelpers = <TItem, TColumnKey extends string>(
     expansionState: { expandedCells }
   } = args;
 
-  const expansionDerivedState = getExpansionDerivedState(args);
+  const expansionDerivedState = useExpansionDerivedState(args);
   const { isCellExpanded, setCellExpanded } = expansionDerivedState;
 
   /**

--- a/packages/module/src/hooks/filtering/index.ts
+++ b/packages/module/src/hooks/filtering/index.ts
@@ -1,4 +1,4 @@
 export * from './useFilterState';
-export * from './getClientFilterDerivedState';
+export * from './useClientFilterDerivedState';
 export * from './useFilterPropHelpers';
 export * from './helpers';

--- a/packages/module/src/hooks/filtering/useClientFilterDerivedState.ts
+++ b/packages/module/src/hooks/filtering/useClientFilterDerivedState.ts
@@ -3,13 +3,13 @@ import { objectKeys } from '../../utils';
 import { FilterState } from './useFilterState';
 
 /**
- * Args for getClientFilterDerivedState
+ * Args for useClientFilterDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
- * - Makes up part of the arguments object taken by getClientTableDerivedState (GetClientTableDerivedStateArgs)
+ * - Makes up part of the arguments object taken by useClientTableDerivedState (UseClientTableDerivedStateArgs)
  * @see TableState
- * @see GetClientTableDerivedStateArgs
+ * @see UseClientTableDerivedStateArgs
  */
-export interface GetClientFilterDerivedStateArgs<TItem, TFilterCategoryKey extends string> {
+export interface UseClientFilterDerivedStateArgs<TItem, TFilterCategoryKey extends string> {
   /**
    * The API data items before filtering
    */
@@ -29,11 +29,11 @@ export interface GetClientFilterDerivedStateArgs<TItem, TFilterCategoryKey exten
  * - For local/client-computed tables only. Performs the actual filtering logic, which is done on the server for server-computed tables.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
-export const getClientFilterDerivedState = <TItem, TFilterCategoryKey extends string>({
+export const useClientFilterDerivedState = <TItem, TFilterCategoryKey extends string>({
   items,
   filterCategories = [],
   filterState: { filterValues }
-}: GetClientFilterDerivedStateArgs<TItem, TFilterCategoryKey>) => {
+}: UseClientFilterDerivedStateArgs<TItem, TFilterCategoryKey>) => {
   const filteredItems = items.filter((item) =>
     objectKeys(filterValues).every((categoryKey) => {
       const values = filterValues[categoryKey];

--- a/packages/module/src/hooks/index.ts
+++ b/packages/module/src/hooks/index.ts
@@ -1,6 +1,6 @@
 export * from './useTableState';
 export * from './useTablePropHelpers';
-export * from './getClientTableDerivedState';
+export * from './useClientTableDerivedState';
 export * from './useClientTableBatteries';
 export * from './generic';
 export * from './filtering';

--- a/packages/module/src/hooks/pagination/index.ts
+++ b/packages/module/src/hooks/pagination/index.ts
@@ -1,4 +1,4 @@
 export * from './usePaginationState';
-export * from './getClientPaginationDerivedState';
+export * from './useClientPaginationDerivedState';
 export * from './usePaginationPropHelpers';
 export * from './usePaginationEffects';

--- a/packages/module/src/hooks/pagination/useClientPaginationDerivedState.ts
+++ b/packages/module/src/hooks/pagination/useClientPaginationDerivedState.ts
@@ -1,13 +1,13 @@
 import { PaginationState } from './usePaginationState';
 
 /**
- * Args for getClientPaginationDerivedState
+ * Args for useClientPaginationDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
- * - Makes up part of the arguments object taken by getClientTableDerivedState (GetClientTableDerivedStateArgs)
+ * - Makes up part of the arguments object taken by useClientTableDerivedState (UseClientTableDerivedStateArgs)
  * @see TableState
- * @see GetClientTableDerivedStateArgs
+ * @see UseClientTableDerivedStateArgs
  */
-export interface GetClientPaginationDerivedStateArgs<TItem> {
+export interface UseClientPaginationDerivedStateArgs<TItem> {
   /**
    * The API data items before pagination (but after filtering)
    */
@@ -23,10 +23,10 @@ export interface GetClientPaginationDerivedStateArgs<TItem> {
  * - For local/client-computed tables only. Performs the actual pagination logic, which is done on the server for server-computed tables.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
-export const getClientPaginationDerivedState = <TItem>({
+export const useClientPaginationDerivedState = <TItem>({
   items,
   paginationState: { pageNumber, itemsPerPage }
-}: GetClientPaginationDerivedStateArgs<TItem>) => {
+}: UseClientPaginationDerivedStateArgs<TItem>) => {
   const pageStartIndex = (pageNumber - 1) * itemsPerPage;
   const currentPageItems = items.slice(pageStartIndex, pageStartIndex + itemsPerPage);
   return { currentPageItems };

--- a/packages/module/src/hooks/pagination/usePaginationEffects.ts
+++ b/packages/module/src/hooks/pagination/usePaginationEffects.ts
@@ -29,7 +29,6 @@ export const usePaginationEffects = ({
   const lastPageNumber = Math.max(Math.ceil(totalItemCount / itemsPerPage), 1);
   React.useEffect(() => {
     if (isPaginationEnabled && pageNumber > lastPageNumber && !isLoading) {
-      // eslint-disable-next-line no-console
       setPageNumber(lastPageNumber);
     }
   }, [isLoading, isPaginationEnabled, itemsPerPage, lastPageNumber, pageNumber, setPageNumber, totalItemCount]);

--- a/packages/module/src/hooks/selection/getSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/getSelectionDerivedState.ts
@@ -108,6 +108,8 @@ export const getSelectionDerivedState = <TItem>(
     // TODO if so, should we convert all the other get*DerivedState stuff to use*DerivedState and maybe even move the use*Effect calls into there and not the prop helpers hooks?
     selectedItems: [], // TODO get these from currentPageItems via a cache: memoize items for ids we've seen that are not in currentPageItems
     isItemSelected,
+    allSelected: false, // TODO
+    pageSelected: false, // TODO
     selectItem: (item, isSelecting = true) => {
       if (isSelecting && !isItemSelected(item) && isItemSelectable(item)) {
         setSelectedItemIds((selected) => [...selected, item[idProperty] as ItemId]);
@@ -142,6 +144,9 @@ export const getSelectionDerivedState = <TItem>(
     },
     selectNone: () => {
       setSelectedItemIds([]);
+    },
+    setSelectedItems: (items: TItem[]) => {
+      setSelectedItemIds(items.map((item) => item[idProperty] as ItemId));
     }
   };
 };

--- a/packages/module/src/hooks/selection/getSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/getSelectionDerivedState.ts
@@ -92,6 +92,8 @@ export const getSelectionDerivedState = <TItem>(
   } = args;
   const isItemSelected = (item: TItem) => selectedItemIds.includes(item[idProperty] as ItemId);
   return {
+    // TODO do we need to turn this into useSelectionDerivedState so we can add the useMemo/useRef/useState cache here?
+    // TODO if so, should we convert all the other get*DerivedState stuff to use*DerivedState and maybe even move the use*Effect calls into there and not the prop helpers hooks?
     selectedItems: [], // TODO get these from currentPageItems via a cache: memoize items for ids we've seen that are not in currentPageItems
     isItemSelected,
     selectItem: (item, isSelecting = true) => {

--- a/packages/module/src/hooks/selection/getSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/getSelectionDerivedState.ts
@@ -41,11 +41,19 @@ export interface SelectionDerivedState<TItem> {
   /**
    * The selected items (full API objects from cache).
    */
-  selectedItems: TItem[];
+  selectedItems: TItem[]; // TODO do we need to make sure these are in table sort order?
   /**
    * Returns whether the given item is selected.
    */
   isItemSelected: (item: TItem) => boolean;
+  /**
+   * Returns whether all items (based on `totalItemCount` argument) are selected.
+   */
+  allSelected: boolean;
+  /**
+   * Returns whether all items in `currentPageItems` are selected (and only those items).
+   */
+  pageSelected: boolean;
   /**
    * Toggles selection on one item. Does not select an item that is not selectable (if an isItemSelectable callback is being used).
    */
@@ -70,6 +78,10 @@ export interface SelectionDerivedState<TItem> {
    * Deselects all items.
    */
   selectNone: () => void;
+  /**
+   * Selects the given selectable items and deselects all other items.
+   */
+  setSelectedItems: (items: TItem[]) => void;
 }
 
 /**

--- a/packages/module/src/hooks/selection/getSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/getSelectionDerivedState.ts
@@ -27,6 +27,10 @@ export interface GetSelectionDerivedStateArgs<TItem> {
    */
   currentPageItems: TItem[];
   /**
+    The total number of items in the entire un-filtered, un-paginated table (the size of the entire API collection being tabulated).
+   */
+  totalItemCount: number;
+  /**
    * All items in the API collection, if available (client-side tables). Enables selectAll.
    */
   items?: TItem[];
@@ -100,16 +104,20 @@ export const getSelectionDerivedState = <TItem>(
     selectionState: { selectedItemIds, setSelectedItemIds },
     isItemSelectable = () => true,
     currentPageItems,
+    totalItemCount,
     items
   } = args;
+  const selectedItems: TItem[] = []; // TODO get these from currentPageItems via a cache: memoize items for ids we've seen that are not in currentPageItems
   const isItemSelected = (item: TItem) => selectedItemIds.includes(item[idProperty] as ItemId);
   return {
     // TODO do we need to turn this into useSelectionDerivedState so we can add the useMemo/useRef/useState cache here?
     // TODO if so, should we convert all the other get*DerivedState stuff to use*DerivedState and maybe even move the use*Effect calls into there and not the prop helpers hooks?
-    selectedItems: [], // TODO get these from currentPageItems via a cache: memoize items for ids we've seen that are not in currentPageItems
+    selectedItems,
     isItemSelected,
-    allSelected: false, // TODO
-    pageSelected: false, // TODO
+    allSelected: selectedItemIds.length === totalItemCount,
+    pageSelected:
+      currentPageItems.length === selectedItemIds.length &&
+      currentPageItems.every((item) => selectedItemIds.includes(item[idProperty] as ItemId)),
     selectItem: (item, isSelecting = true) => {
       if (isSelecting && !isItemSelected(item) && isItemSelectable(item)) {
         setSelectedItemIds((selected) => [...selected, item[idProperty] as ItemId]);

--- a/packages/module/src/hooks/selection/getSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/getSelectionDerivedState.ts
@@ -1,0 +1,65 @@
+import { KeyWithValueType } from '../../type-utils';
+import { SelectionState } from './useSelectionState';
+
+/**
+ * Args for getSelectionDerivedState
+ * - Partially satisfied by the object returned by useTableState (TableState)
+ * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
+ * @see TableState
+ * @see UseTablePropHelpersArgs
+ */
+export interface GetSelectionDerivedStateArgs<TItem> {
+  /**
+   * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
+   */
+  idProperty: KeyWithValueType<TItem, string | number>;
+  /**
+   * The "source of truth" state for the selection feature (returned by useSelectionState)
+   */
+  selectionState: SelectionState;
+  /**
+   * Callback to determine if a given item is allowed to be selected. Blocks that item from being present in state.
+   */
+  isItemSelectable?: (item: TItem) => boolean;
+}
+
+/**
+ * Derived state for the selection feature
+ * - "Derived state" here refers to values and convenience functions derived at render time based on the "source of truth" state.
+ * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
+ */
+export interface SelectionDerivedState<TItem> {
+  /**
+   * The selected items on the current pagination page.
+   */
+  selectedItems: TItem[];
+  /**
+   * Toggles selection on one item. Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectItem: (item: TItem, isSelecting?: boolean) => void;
+  /**
+   * Toggles selection on multiple items
+   * - If any items are not selected, isSelecting will default to true.
+   * - Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectMultipleItems: (items: TItem[], isSelecting?: boolean) => void;
+  /**
+   * Selects all selectable items on the current page.
+   * - Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectAll: () => void;
+  /**
+   * Deselects all items.
+   */
+  selectNone: () => void;
+}
+
+/**
+ * Given the "source of truth" state for the selection feature and additional arguments, returns "derived state" values and convenience functions.
+ * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
+ *
+ * NOTE: Unlike `getClient[Filter|Sort|Pagination]DerivedState`, this is not named `getClientSelectionDerivedState` because it
+ * is always local/client-computed, and it is still used when working with server-computed tables
+ * (it's not specific to client-only-computed tables like the other `getClient*DerivedState` functions are).
+ */
+export const getSelectionDerivedState = () => {};

--- a/packages/module/src/hooks/selection/index.ts
+++ b/packages/module/src/hooks/selection/index.ts
@@ -1,4 +1,4 @@
 export * from './useSelectionState';
 export * from './useSelectionPropHelpers';
-export * from './getSelectionDerivedState';
+export * from './useSelectionDerivedState';
 export * from './useSelectionEffects';

--- a/packages/module/src/hooks/selection/index.ts
+++ b/packages/module/src/hooks/selection/index.ts
@@ -1,0 +1,3 @@
+export * from './useSelectionState';
+export * from './useSelectionPropHelpers';
+export * from './getSelectionDerivedState';

--- a/packages/module/src/hooks/selection/index.ts
+++ b/packages/module/src/hooks/selection/index.ts
@@ -1,3 +1,4 @@
 export * from './useSelectionState';
 export * from './useSelectionPropHelpers';
 export * from './getSelectionDerivedState';
+export * from './useSelectionEffects';

--- a/packages/module/src/hooks/selection/useSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/useSelectionDerivedState.ts
@@ -101,7 +101,7 @@ export const useSelectionDerivedState = <TItem>(
 ): SelectionDerivedState<TItem> => {
   const {
     idProperty,
-    selectionState: { selectedItemIds, setSelectedItemIds },
+    selectionState: { selectedItemIds = [], setSelectedItemIds },
     isItemSelectable = () => true,
     currentPageItems,
     totalItemCount,

--- a/packages/module/src/hooks/selection/useSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/useSelectionDerivedState.ts
@@ -3,13 +3,13 @@ import { ItemId } from '../../types';
 import { SelectionState } from './useSelectionState';
 
 /**
- * Args for getSelectionDerivedState
+ * Args for useSelectionDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
  * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export interface GetSelectionDerivedStateArgs<TItem> {
+export interface UseSelectionDerivedStateArgs<TItem> {
   /**
    * The string key/name of a property on the API data item objects that can be used as a unique identifier (string or number)
    */
@@ -96,8 +96,8 @@ export interface SelectionDerivedState<TItem> {
  * is always local/client-computed, and it is still used when working with server-computed tables
  * (it's not specific to client-only-computed tables like the other `getClient*DerivedState` functions are).
  */
-export const getSelectionDerivedState = <TItem>(
-  args: GetSelectionDerivedStateArgs<TItem>
+export const useSelectionDerivedState = <TItem>(
+  args: UseSelectionDerivedStateArgs<TItem>
 ): SelectionDerivedState<TItem> => {
   const {
     idProperty,

--- a/packages/module/src/hooks/selection/useSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/useSelectionDerivedState.ts
@@ -77,7 +77,7 @@ export interface SelectionDerivedState<TItem> {
    * Selects all selectable items on the current page.
    * - Does not select an item that is not selectable (if an isItemSelectable callback is being used).
    */
-  selectPage: () => void;
+  selectPage: (selecting?: boolean) => void;
   /**
    * Deselects all items.
    */
@@ -147,8 +147,12 @@ export const useSelectionDerivedState = <TItem>(
       }
       setSelectedItemIds(items.filter(isItemSelectable).map((item) => item[idProperty] as ItemId));
     },
-    selectPage: () => {
-      setSelectedItemIds(currentPageItems.filter(isItemSelectable).map((item) => item[idProperty] as ItemId));
+    selectPage: (selecting = true) => {
+      if (selecting) {
+        setSelectedItemIds(currentPageItems.filter(isItemSelectable).map((item) => item[idProperty] as ItemId));
+      } else {
+        setSelectedItemIds([]);
+      }
     },
     selectNone: () => {
       setSelectedItemIds([]);

--- a/packages/module/src/hooks/selection/useSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/useSelectionDerivedState.ts
@@ -46,7 +46,7 @@ export interface SelectionDerivedState<TItem> {
   /**
    * The selected items (full API objects from cache).
    */
-  selectedItems: TItem[]; // TODO do we need to make sure these are in table sort order?
+  selectedItems: TItem[];
   /**
    * Returns whether the given item is selected.
    */
@@ -111,15 +111,14 @@ export const useSelectionDerivedState = <TItem>(
   // We memoize any item objects we've seen that match selectedItemIds, even if they are no longer in currentPageItems.
   const selectedItemCacheRef = React.useRef<Record<ItemId, TItem>>({});
   const selectedItems: TItem[] = React.useMemo(() => {
-    currentPageItems.forEach((item) => {
+    (items || currentPageItems).forEach((item) => {
       const itemId = item[idProperty] as ItemId;
       if (selectedItemCacheRef.current[itemId] !== item && selectedItemIds.includes(itemId)) {
         selectedItemCacheRef.current[itemId] = item;
       }
     });
-    // This assertion is safe because the cache should always include all items that have ever been present in selectedItemIds in the current session.
-    return selectedItemIds.map((id) => selectedItemCacheRef.current[id] as TItem);
-  }, [currentPageItems, idProperty, selectedItemIds]);
+    return selectedItemIds.map((id) => selectedItemCacheRef.current[id]).filter(Boolean) as TItem[];
+  }, [currentPageItems, items, idProperty, selectedItemIds]);
 
   const isItemSelected = (item: TItem) => selectedItemIds.includes(item[idProperty] as ItemId);
   return {

--- a/packages/module/src/hooks/selection/useSelectionDerivedState.ts
+++ b/packages/module/src/hooks/selection/useSelectionDerivedState.ts
@@ -89,15 +89,13 @@ export interface SelectionDerivedState<TItem> {
   setSelectedItems: (items: TItem[]) => void;
 }
 
-// TODO should we convert all the other get*DerivedState stuff to use*DerivedState and maybe even move the use*Effect calls into there and not the prop helpers hooks?
-
 /**
  * Given the "source of truth" state for the selection feature and additional arguments, returns "derived state" values and convenience functions.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  *
- * NOTE: Unlike `getClient[Filter|Sort|Pagination]DerivedState`, this is not named `getClientSelectionDerivedState` because it
+ * NOTE: Unlike `useClient[Filter|Sort|Pagination]DerivedState`, this is not named `useClientSelectionDerivedState` because it
  * is always local/client-computed, and it is still used when working with server-computed tables
- * (it's not specific to client-only-computed tables like the other `getClient*DerivedState` functions are).
+ * (it's not specific to client-only-computed tables like the other `useClient*DerivedState` functions are).
  */
 export const useSelectionDerivedState = <TItem>(
   args: UseSelectionDerivedStateArgs<TItem>

--- a/packages/module/src/hooks/selection/useSelectionEffects.ts
+++ b/packages/module/src/hooks/selection/useSelectionEffects.ts
@@ -1,11 +1,21 @@
 import React from 'react';
+import { SelectionDerivedState } from './getSelectionDerivedState';
 
-// TODO effects! pass in args, etc.
+// TODO finish implementing effects pattern here!
 
-export const useSelectionEffects = () => {
+export interface UseSelectionEffectsArgs<TItem> {
+  isItemSelectable?: (item: TItem) => boolean;
+  selectionDerivedState: SelectionDerivedState<TItem>;
+}
+
+export const useSelectionEffects = <TItem>(args: UseSelectionEffectsArgs<TItem>) => {
   // If isItemSelectable changes and a selected item is no longer selectable, deselect it
+  const {
+    isItemSelectable,
+    selectionDerivedState: { selectedItems, setSelectedItems }
+  } = args;
   React.useEffect(() => {
-    if (!selectedItems.every(isItemSelectable)) {
+    if (isItemSelectable && !selectedItems.every(isItemSelectable)) {
       setSelectedItems(selectedItems.filter(isItemSelectable));
     }
   }, [isItemSelectable, selectedItems, setSelectedItems]);

--- a/packages/module/src/hooks/selection/useSelectionEffects.ts
+++ b/packages/module/src/hooks/selection/useSelectionEffects.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+// TODO effects! pass in args, etc.
+
+export const useSelectionEffects = () => {
+  // If isItemSelectable changes and a selected item is no longer selectable, deselect it
+  React.useEffect(() => {
+    if (!selectedItems.every(isItemSelectable)) {
+      setSelectedItems(selectedItems.filter(isItemSelectable));
+    }
+  }, [isItemSelectable, selectedItems, setSelectedItems]);
+};

--- a/packages/module/src/hooks/selection/useSelectionEffects.ts
+++ b/packages/module/src/hooks/selection/useSelectionEffects.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SelectionDerivedState } from './getSelectionDerivedState';
+import { SelectionDerivedState } from './useSelectionDerivedState';
 
 export interface UseSelectionEffectsArgs<TItem> {
   isItemSelectable?: (item: TItem) => boolean;

--- a/packages/module/src/hooks/selection/useSelectionEffects.ts
+++ b/packages/module/src/hooks/selection/useSelectionEffects.ts
@@ -1,19 +1,16 @@
 import React from 'react';
 import { SelectionDerivedState } from './getSelectionDerivedState';
 
-// TODO finish implementing effects pattern here!
-
 export interface UseSelectionEffectsArgs<TItem> {
   isItemSelectable?: (item: TItem) => boolean;
   selectionDerivedState: SelectionDerivedState<TItem>;
 }
 
-export const useSelectionEffects = <TItem>(args: UseSelectionEffectsArgs<TItem>) => {
+export const useSelectionEffects = <TItem>({
+  isItemSelectable,
+  selectionDerivedState: { selectedItems, setSelectedItems }
+}: UseSelectionEffectsArgs<TItem>) => {
   // If isItemSelectable changes and a selected item is no longer selectable, deselect it
-  const {
-    isItemSelectable,
-    selectionDerivedState: { selectedItems, setSelectedItems }
-  } = args;
   React.useEffect(() => {
     if (isItemSelectable && !selectedItems.every(isItemSelectable)) {
       setSelectedItems(selectedItems.filter(isItemSelectable));

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -30,7 +30,7 @@ export const useSelectionPropHelpers = <TItem>(
 ) => {
   const { paginationProps, currentPageItems } = args;
   const selectionDerivedState = useSelectionDerivedState(args);
-  const { selectAll, selectItem, selectItems, selectedItems, isItemSelected, allSelected } = selectionDerivedState;
+  const { selectPage, selectItem, selectItems, selectedItems, isItemSelected, allSelected } = selectionDerivedState;
 
   useSelectionEffects({ ...args, selectionDerivedState });
 
@@ -38,7 +38,7 @@ export const useSelectionPropHelpers = <TItem>(
    * Props for the ToolbarBulkSelector component.
    */
   const toolbarBulkSelectorProps: ToolbarBulkSelectorProps<TItem> = {
-    onSelectAll: selectAll,
+    onSelectAll: selectPage,
     areAllSelected: allSelected,
     selectedRows: selectedItems,
     paginationProps,

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -1,1 +1,45 @@
 // TODO implement that behavior from PF docs where groups of items can be selected by shift+clicking or ctrl+clicking on checkboxes
+
+import { GetSelectionDerivedStateArgs, getSelectionDerivedState } from './getSelectionDerivedState';
+import { SelectionState } from './useSelectionState';
+
+// // TODO move this to a useSelectionPropHelpers when we move selection from lib-ui
+// const toolbarBulkSelectorProps: PropHelpers['toolbarBulkSelectorProps'] = {
+//   onSelectAll: selectAll,
+//   areAllSelected,
+//   selectedRows: selectedItems,
+//   paginationProps,
+//   currentPageItems,
+//   onSelectMultiple: selectMultiple
+// };
+
+// // TODO move this into a useSelectionPropHelpers and make it part of getTdProps once we move selection from lib-ui
+// const getSelectCheckboxTdProps: PropHelpers['getSelectCheckboxTdProps'] = ({ item, rowIndex }) => ({
+//   select: {
+//     rowIndex,
+//     onSelect: (_event, isSelecting) => {
+//       toggleItemSelected(item, isSelecting);
+//     },
+//     isSelected: isItemSelected(item)
+//   }
+// });
+
+/**
+ * Args for useSelectionPropHelpers that come from outside useTablePropHelpers
+ * - Partially satisfied by the object returned by useTableState (TableState)
+ * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
+ * @see TableState
+ * @see UseTablePropHelpersArgs
+ */
+export type UseSelectionPropHelpersExternalArgs<TItem> = GetSelectionDerivedStateArgs<TItem> & {
+  /**
+   * The "source of truth" state for the selection feature (returned by useSelectionState)
+   */
+  selectionState: SelectionState;
+};
+
+export const useSelectionPropHelpers = <TItem>(args: UseSelectionPropHelpersExternalArgs<TItem>) => {
+  const selectionDerivedState = getSelectionDerivedState(args);
+  console.log('TODO!'); // TODO
+  return { selectionDerivedState, toolbarBulkSelectorProps, getSelectCheckboxTdProps };
+};

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -28,9 +28,10 @@ export interface UseSelectionPropHelpersInternalArgs {
 export const useSelectionPropHelpers = <TItem>(
   args: UseSelectionPropHelpersExternalArgs<TItem> & UseSelectionPropHelpersInternalArgs
 ) => {
-  const { paginationProps, currentPageItems } = args;
+  const { paginationProps, currentPageItems, items } = args;
   const selectionDerivedState = useSelectionDerivedState(args);
-  const { selectPage, selectItem, selectItems, selectedItems, isItemSelected, allSelected } = selectionDerivedState;
+  const { selectItem, selectItems, selectAll, selectNone, selectedItems, isItemSelected, allSelected } =
+    selectionDerivedState;
 
   useSelectionEffects({ ...args, selectionDerivedState });
 
@@ -38,7 +39,8 @@ export const useSelectionPropHelpers = <TItem>(
    * Props for the ToolbarBulkSelector component.
    */
   const toolbarBulkSelectorProps: ToolbarBulkSelectorProps<TItem> = {
-    onSelectAll: selectPage,
+    onSelectAll: items ? selectAll : undefined, // If we don't have all items in scope, we can't select all
+    onSelectNone: selectNone,
     areAllSelected: allSelected,
     selectedRows: selectedItems,
     paginationProps,

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -1,6 +1,6 @@
 import { PaginationProps } from '@patternfly/react-core';
 import { ToolbarBulkSelectorProps } from '../../tackle2-ui-legacy/components/ToolbarBulkSelector';
-import { GetSelectionDerivedStateArgs, getSelectionDerivedState } from './getSelectionDerivedState';
+import { UseSelectionDerivedStateArgs, useSelectionDerivedState } from './useSelectionDerivedState';
 import { UseSelectionEffectsArgs, useSelectionEffects } from './useSelectionEffects';
 import { TdProps } from '@patternfly/react-table';
 /**
@@ -10,7 +10,7 @@ import { TdProps } from '@patternfly/react-table';
  * @see TableState
  * @see UseTablePropHelpersArgs
  */
-export type UseSelectionPropHelpersExternalArgs<TItem> = GetSelectionDerivedStateArgs<TItem> &
+export type UseSelectionPropHelpersExternalArgs<TItem> = UseSelectionDerivedStateArgs<TItem> &
   Omit<UseSelectionEffectsArgs<TItem>, 'selectionDerivedState'> & {
     /**
      * The current page of API data items after filtering/sorting/pagination
@@ -34,7 +34,7 @@ export const useSelectionPropHelpers = <TItem>(
   args: UseSelectionPropHelpersExternalArgs<TItem> & UseSelectionPropHelpersInternalArgs
 ) => {
   const { paginationProps, currentPageItems } = args;
-  const selectionDerivedState = getSelectionDerivedState(args);
+  const selectionDerivedState = useSelectionDerivedState(args);
   const { selectAll, selectItem, selectItems, selectedItems, isItemSelected, allSelected } = selectionDerivedState;
 
   useSelectionEffects({ ...args, selectionDerivedState });

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -11,12 +11,7 @@ import { TdProps } from '@patternfly/react-table';
  * @see UseTablePropHelpersArgs
  */
 export type UseSelectionPropHelpersExternalArgs<TItem> = UseSelectionDerivedStateArgs<TItem> &
-  Omit<UseSelectionEffectsArgs<TItem>, 'selectionDerivedState'> & {
-    /**
-     * The current page of API data items after filtering/sorting/pagination
-     */
-    currentPageItems: TItem[];
-  };
+  Omit<UseSelectionEffectsArgs<TItem>, 'selectionDerivedState'>;
 
 /**
  * Additional args for useSelectionPropHelpers that come from logic inside useTablePropHelpers

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -1,0 +1,1 @@
+// TODO implement that behavior from PF docs where groups of items can be selected by shift+clicking or ctrl+clicking on checkboxes

--- a/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
+++ b/packages/module/src/hooks/selection/useSelectionPropHelpers.ts
@@ -28,7 +28,7 @@ export interface UseSelectionPropHelpersInternalArgs {
 export const useSelectionPropHelpers = <TItem>(
   args: UseSelectionPropHelpersExternalArgs<TItem> & UseSelectionPropHelpersInternalArgs
 ) => {
-  const { paginationProps, currentPageItems, items } = args;
+  const { paginationProps, currentPageItems, items, isItemSelectable } = args;
   const selectionDerivedState = useSelectionDerivedState(args);
   const { selectItem, selectItems, selectAll, selectNone, selectedItems, isItemSelected, allSelected } =
     selectionDerivedState;
@@ -60,7 +60,8 @@ export const useSelectionPropHelpers = <TItem>(
       onSelect: (_event, isSelecting) => {
         selectItem(item, isSelecting);
       },
-      isSelected: isItemSelected(item)
+      isSelected: isItemSelected(item),
+      isDisabled: isItemSelectable && !isItemSelectable(item)
     }
   });
 

--- a/packages/module/src/hooks/selection/useSelectionState.ts
+++ b/packages/module/src/hooks/selection/useSelectionState.ts
@@ -1,0 +1,112 @@
+import { DiscriminatedArgs } from '../../type-utils';
+import { ItemId, FeaturePersistenceArgs } from '../../types';
+import { usePersistentState } from '../generic/usePersistentState';
+
+/**
+ * The "source of truth" state for the selection feature.
+ * - Included in the object returned by useTableState (TableState) under the `selectionState` property.
+ * - Also included in the `TableBatteries` object returned by useTablePropHelpers and useClientTableBatteries.
+ * @see TableState
+ * @see TableBatteries
+ */
+export interface SelectionState<TItem> {
+  /**
+   * The ids of the currently selected items
+   */
+  selectedItemIds: ItemId[];
+  /**
+   * Updates the entire list of selected item ids
+   */
+  setSelectedItemIds: (ids: ItemId[]) => void;
+  // TODO do the below shorthand helpers belong here or in useSelectionPropHelpers? I think here, but do we need to move any stuff for other features into the state hooks to be consistent?
+  /**
+   * Toggles selection on one item. Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectItem: (item: TItem, isSelecting?: boolean) => void;
+  /**
+   * Toggles selection on multiple items
+   * - If any items are not selected, isSelecting will default to true.
+   * - Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectMultipleItems: (items: TItem[], isSelecting?: boolean) => void;
+  /**
+   * Selects all selectable items.
+   * - Does not select an item that is not selectable (if an isItemSelectable callback is being used).
+   */
+  selectAll: () => void;
+  /**
+   * Deselects all items.
+   */
+  selectNone: () => void;
+}
+
+/**
+ * Args for useSelectionState
+ * - Makes up part of the arguments object taken by useTableState (UseTableStateArgs)
+ * - The properties defined here are only required by useTableState if isSelectionEnabled is true (see DiscriminatedArgs)
+ * - Properties here are included in the `TableBatteries` object returned by useTablePropHelpers and useClientTableBatteries.
+ * @see UseTableStateArgs
+ * @see DiscriminatedArgs
+ * @see TableBatteries
+ */
+export type UseSelectionStateArgs<TItem> = DiscriminatedArgs<
+  'isSelectionEnabled',
+  {
+    /**
+     * Ids of items to have pre-selected on first render
+     */
+    initialSelectedItemIds?: ItemId[];
+    /**
+     * Callback to determine if a given item is allowed to be selected. Blocks that item from being present in state.
+     */
+    isItemSelectable?: (item: TItem) => boolean;
+  }
+>;
+
+/**
+ * Provides the "source of truth" state for the sort feature.
+ * - Used internally by useTableState
+ * - Takes args defined above as well as optional args for persisting state to a configurable storage target.
+ * @see PersistTarget
+ */
+export const useSelectionState = <TItem, TPersistenceKeyPrefix extends string = string>(
+  args: UseSelectionStateArgs<TItem> & FeaturePersistenceArgs<TPersistenceKeyPrefix>
+): SelectionState<TItem> => {
+  const { isSelectionEnabled, persistTo = 'state', persistenceKeyPrefix } = args;
+
+  /// LEFT OFF HERE
+
+  // We won't need to pass the latter two type params here if TS adds support for partial inference.
+  // See https://github.com/konveyor/tackle2-ui/issues/1456
+  const [selectedItemIds, setSelectedItemIds] = usePersistentState<ItemId[], TPersistenceKeyPrefix, 'selected'>({
+    isEnabled: !!isSelectionEnabled,
+    defaultValue: initialSelection,
+    persistenceKeyPrefix,
+    // Note: For the discriminated union here to work without TypeScript getting confused
+    //       (e.g. require the urlParams-specific options when persistTo === "urlParams"),
+    //       we need to pass persistTo inside each type-narrowed options object instead of outside the ternary.
+    ...(persistTo === 'urlParams'
+      ? {
+          persistTo,
+          keys: ['sortColumn', 'sortDirection'],
+          serialize: (activeSelection) => ({
+            sortColumn: activeSelection?.columnKey || null,
+            sortDirection: activeSelection?.direction || null
+          }),
+          deserialize: (urlParams) =>
+            urlParams.sortColumn && urlParams.sortDirection
+              ? {
+                  columnKey: urlParams.sortColumn as TSelectionableColumnKey,
+                  direction: urlParams.sortDirection as 'asc' | 'desc'
+                }
+              : null
+        }
+      : persistTo === 'localStorage' || persistTo === 'sessionStorage'
+      ? {
+          persistTo,
+          key: 'sort'
+        }
+      : { persistTo })
+  });
+  return { activeSelection, setActiveSelection };
+};

--- a/packages/module/src/hooks/selection/useSelectionState.ts
+++ b/packages/module/src/hooks/selection/useSelectionState.ts
@@ -43,7 +43,7 @@ export type UseSelectionStateArgs = DiscriminatedArgs<
  * Provides the "source of truth" state for the selection feature.
  * - Used internally by useTableState
  * - NOTE: usePersistentState is not used here because in order to work correctly,
- *   selection state cannot be persisted. The `selectedItems` array we get from `getSelectionDerivedState`
+ *   selection state cannot be persisted. The `selectedItems` array we get from `useSelectionDerivedState`
  *   is based on a cache of the API items that have been seen in the current session.
  *   if we need to restore selection state on a page reload, we no longer have all the selected item data
  *   in memory. We just use a plain React.useState here and if we have selected items in state we'll

--- a/packages/module/src/hooks/sorting/index.ts
+++ b/packages/module/src/hooks/sorting/index.ts
@@ -1,3 +1,3 @@
 export * from './useSortState';
-export * from './getClientSortDerivedState';
+export * from './useClientSortDerivedState';
 export * from './useSortPropHelpers';

--- a/packages/module/src/hooks/sorting/useClientSortDerivedState.ts
+++ b/packages/module/src/hooks/sorting/useClientSortDerivedState.ts
@@ -1,13 +1,13 @@
 import { SortState } from './useSortState';
 
 /**
- * Args for getClientSortDerivedState
+ * Args for useClientSortDerivedState
  * - Partially satisfied by the object returned by useTableState (TableState)
- * - Makes up part of the arguments object taken by getClientTableDerivedState (GetClientTableDerivedStateArgs)
+ * - Makes up part of the arguments object taken by useClientTableDerivedState (UseClientTableDerivedStateArgs)
  * @see TableState
- * @see GetClientTableDerivedStateArgs
+ * @see UseClientTableDerivedStateArgs
  */
-export interface GetClientSortDerivedStateArgs<TItem, TSortableColumnKey extends string> {
+export interface UseClientSortDerivedStateArgs<TItem, TSortableColumnKey extends string> {
   /**
    * The API data items before sorting
    */
@@ -33,11 +33,11 @@ export interface GetClientSortDerivedStateArgs<TItem, TSortableColumnKey extends
  * - For local/client-computed tables only. Performs the actual sorting logic, which is done on the server for server-computed tables.
  * - "source of truth" (persisted) state and "derived state" are kept separate to prevent out-of-sync duplicated state.
  */
-export const getClientSortDerivedState = <TItem, TSortableColumnKey extends string>({
+export const useClientSortDerivedState = <TItem, TSortableColumnKey extends string>({
   items,
   getSortValues,
   sortState: { activeSort }
-}: GetClientSortDerivedStateArgs<TItem, TSortableColumnKey>) => {
+}: UseClientSortDerivedStateArgs<TItem, TSortableColumnKey>) => {
   if (!getSortValues || !activeSort) {
     return { sortedItems: items };
   }

--- a/packages/module/src/hooks/useClientTableBatteries.ts
+++ b/packages/module/src/hooks/useClientTableBatteries.ts
@@ -1,11 +1,5 @@
 import { useTablePropHelpers } from './useTablePropHelpers';
-import {
-  GetClientTableDerivedStateArgs,
-  TableBatteries,
-  TableState,
-  UseClientTableBatteriesArgs,
-  UseTablePropHelpersArgs
-} from '../types';
+import { TableBatteries, TableDerivedState, TableState, UseClientTableBatteriesArgs } from '../types';
 import { getClientTableDerivedState } from './getClientTableDerivedState';
 import { useTableState } from './useTableState';
 
@@ -26,27 +20,20 @@ export const useClientTableBatteries = <
 ): TableBatteries<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> => {
   const state = useTableState(args);
 
-  // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
-  // TODO do we have an actual issue with types here or is this a limitation of TS inference?
-  const derivedState = getClientTableDerivedState({ ...args, ...state } as TableState<
+  type Args = UseClientTableBatteriesArgs<
     TItem,
     TColumnKey,
     TSortableColumnKey,
     TFilterCategoryKey,
     TPersistenceKeyPrefix
-  > &
-    GetClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>);
-
-  const argsForGetClientTableDerivedState = { ...args, ...state };
-  const argsForUseTablePropHelpers = { ...args, ...state, ...derivedState };
-  // eslint-disable-next-line no-console
-  console.log({ argsForGetClientTableDerivedState, argsForUseTablePropHelpers });
+  >;
+  type State = TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>;
 
   // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
   // TODO do we have an actual issue with types here or is this a limitation of TS inference?
-  return useTablePropHelpers({
-    ...args,
-    ...state,
-    ...derivedState
-  } as UseTablePropHelpersArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>);
+  const derivedState = getClientTableDerivedState({ ...args, ...state } as Args & State);
+
+  // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
+  // TODO do we have an actual issue with types here or is this a limitation of TS inference?
+  return useTablePropHelpers({ ...args, ...state, ...derivedState } as Args & State & TableDerivedState<TItem>);
 };

--- a/packages/module/src/hooks/useClientTableBatteries.ts
+++ b/packages/module/src/hooks/useClientTableBatteries.ts
@@ -25,6 +25,7 @@ export const useClientTableBatteries = <
   args: UseClientTableBatteriesArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
 ): TableBatteries<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> => {
   const state = useTableState(args);
+
   // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
   // TODO do we have an actual issue with types here or is this a limitation of TS inference?
   const derivedState = getClientTableDerivedState({ ...args, ...state } as TableState<
@@ -35,6 +36,12 @@ export const useClientTableBatteries = <
     TPersistenceKeyPrefix
   > &
     GetClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>);
+
+  const argsForGetClientTableDerivedState = { ...args, ...state };
+  const argsForUseTablePropHelpers = { ...args, ...state, ...derivedState };
+  // eslint-disable-next-line no-console
+  console.log({ argsForGetClientTableDerivedState, argsForUseTablePropHelpers });
+
   // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
   // TODO do we have an actual issue with types here or is this a limitation of TS inference?
   return useTablePropHelpers({

--- a/packages/module/src/hooks/useClientTableBatteries.ts
+++ b/packages/module/src/hooks/useClientTableBatteries.ts
@@ -1,6 +1,6 @@
 import { useTablePropHelpers } from './useTablePropHelpers';
 import { TableBatteries, TableDerivedState, TableState, UseClientTableBatteriesArgs } from '../types';
-import { getClientTableDerivedState } from './getClientTableDerivedState';
+import { useClientTableDerivedState } from './useClientTableDerivedState';
 import { useTableState } from './useTableState';
 
 /**
@@ -31,7 +31,7 @@ export const useClientTableBatteries = <
 
   // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
   // TODO do we have an actual issue with types here or is this a limitation of TS inference?
-  const derivedState = getClientTableDerivedState({ ...args, ...state } as Args & State);
+  const derivedState = useClientTableDerivedState({ ...args, ...state } as Args & State);
 
   // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
   // TODO do we have an actual issue with types here or is this a limitation of TS inference?

--- a/packages/module/src/hooks/useClientTableBatteries.ts
+++ b/packages/module/src/hooks/useClientTableBatteries.ts
@@ -2,7 +2,6 @@ import { useTablePropHelpers } from './useTablePropHelpers';
 import { TableBatteries, UseClientTableBatteriesArgs } from '../types';
 import { getClientTableDerivedState } from './getClientTableDerivedState';
 import { useTableState } from './useTableState';
-import { useSelectionState } from '@migtools/lib-ui';
 
 /**
  * Provides all state, derived state, side-effects and prop helpers needed to manage a local/client-computed table.
@@ -20,15 +19,14 @@ export const useClientTableBatteries = <
   args: UseClientTableBatteriesArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
 ): TableBatteries<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> => {
   const state = useTableState(args);
+  console.log('Compare with properties expected by getClientTableDerivedSDtate: ', { ...args, ...state });
   const derivedState = getClientTableDerivedState({ ...args, ...state });
   return useTablePropHelpers({
     ...args,
     ...state,
-    ...derivedState,
-    // TODO we won't need this here once selection state is part of useTableState
-    selectionState: useSelectionState({
-      ...args,
-      isEqual: (a, b) => a[args.idProperty] === b[args.idProperty]
-    })
+    ...derivedState
   });
 };
+
+// TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
+// & GetClientFilterDerivedStateArgs<...> & GetClientSortDerivedStateArgs<...> & GetClientPaginationDerivedStateArgs<...>

--- a/packages/module/src/hooks/useClientTableBatteries.ts
+++ b/packages/module/src/hooks/useClientTableBatteries.ts
@@ -1,5 +1,11 @@
 import { useTablePropHelpers } from './useTablePropHelpers';
-import { TableBatteries, UseClientTableBatteriesArgs } from '../types';
+import {
+  GetClientTableDerivedStateArgs,
+  TableBatteries,
+  TableState,
+  UseClientTableBatteriesArgs,
+  UseTablePropHelpersArgs
+} from '../types';
 import { getClientTableDerivedState } from './getClientTableDerivedState';
 import { useTableState } from './useTableState';
 
@@ -19,14 +25,21 @@ export const useClientTableBatteries = <
   args: UseClientTableBatteriesArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
 ): TableBatteries<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> => {
   const state = useTableState(args);
-  console.log('Compare with properties expected by getClientTableDerivedSDtate: ', { ...args, ...state });
-  const derivedState = getClientTableDerivedState({ ...args, ...state });
+  // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
+  // TODO do we have an actual issue with types here or is this a limitation of TS inference?
+  const derivedState = getClientTableDerivedState({ ...args, ...state } as TableState<
+    TItem,
+    TColumnKey,
+    TSortableColumnKey,
+    TFilterCategoryKey,
+    TPersistenceKeyPrefix
+  > &
+    GetClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>);
+  // TODO figure out why the `as` below is necessary, the `{ ...args, ...state }` should be enough for TS to infer the rest
+  // TODO do we have an actual issue with types here or is this a limitation of TS inference?
   return useTablePropHelpers({
     ...args,
     ...state,
     ...derivedState
-  });
+  } as UseTablePropHelpersArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>);
 };
-
-// TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>
-// & GetClientFilterDerivedStateArgs<...> & GetClientSortDerivedStateArgs<...> & GetClientPaginationDerivedStateArgs<...>

--- a/packages/module/src/hooks/useClientTableDerivedState.ts
+++ b/packages/module/src/hooks/useClientTableDerivedState.ts
@@ -1,7 +1,7 @@
-import { getClientFilterDerivedState } from './filtering';
-import { getClientSortDerivedState } from './sorting';
-import { getClientPaginationDerivedState } from './pagination';
-import { GetClientTableDerivedStateArgs, TableDerivedState, TableState } from '../types';
+import { useClientFilterDerivedState } from './filtering';
+import { useClientSortDerivedState } from './sorting';
+import { useClientPaginationDerivedState } from './pagination';
+import { UseClientTableDerivedStateArgs, TableDerivedState, TableState } from '../types';
 
 /**
  * Returns table-level "derived state" (the results of local/client-computed filtering/sorting/pagination)
@@ -9,7 +9,7 @@ import { GetClientTableDerivedStateArgs, TableDerivedState, TableState } from '.
  * - Takes "source of truth" state for all features and additional args.
  * @see useClientTableBatteries
  */
-export const getClientTableDerivedState = <
+export const useClientTableDerivedState = <
   TItem,
   TColumnKey extends string,
   TSortableColumnKey extends TColumnKey,
@@ -17,18 +17,18 @@ export const getClientTableDerivedState = <
   TPersistenceKeyPrefix extends string = string
 >(
   args: TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> &
-    GetClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>
+    UseClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>
 ): TableDerivedState<TItem> => {
   const { items, isPaginationEnabled = true } = args;
-  const { filteredItems } = getClientFilterDerivedState({
+  const { filteredItems } = useClientFilterDerivedState({
     ...args,
     items
   });
-  const { sortedItems } = getClientSortDerivedState({
+  const { sortedItems } = useClientSortDerivedState({
     ...args,
     items: filteredItems
   });
-  const { currentPageItems } = getClientPaginationDerivedState({
+  const { currentPageItems } = useClientPaginationDerivedState({
     ...args,
     items: sortedItems
   });

--- a/packages/module/src/hooks/useTablePropHelpers.ts
+++ b/packages/module/src/hooks/useTablePropHelpers.ts
@@ -4,8 +4,9 @@ import { TableBatteries, UseTablePropHelpersArgs } from '../types';
 import { useFilterPropHelpers } from './filtering';
 import { useSortPropHelpers } from './sorting';
 import { usePaginationPropHelpers } from './pagination';
-import { useActiveItemPropHelpers } from './active-item';
+import { useSelectionPropHelpers } from './selection';
 import { useExpansionPropHelpers } from './expansion';
+import { useActiveItemPropHelpers } from './active-item';
 import { handlePropagatedRowClick, objectKeys } from '../utils';
 
 /**
@@ -40,9 +41,7 @@ export const useTablePropHelpers = <
   //       args object is passed to other other helpers which require other parts of it.
   //       For future additions, inspect `args` to see if it has anything more you need.
   const {
-    currentPageItems,
     forceNumRenderedColumns,
-    selectionState: { selectAll, areAllSelected, selectedItems, selectMultiple, toggleItemSelected, isItemSelected },
     columnNames,
     hasActionsColumn = false,
     variant,
@@ -73,6 +72,7 @@ export const useTablePropHelpers = <
   const { filterPropsForToolbar, propsForFilterToolbar } = useFilterPropHelpers(args);
   const { getSortThProps } = useSortPropHelpers({ ...args, columnKeys });
   const { paginationProps, paginationToolbarItemProps } = usePaginationPropHelpers(args);
+  const { selectionDerivedState, toolbarBulkSelectorProps, getSelectCheckboxTdProps } = useSelectionPropHelpers(args); // TODO
   const { expansionDerivedState, getSingleExpandButtonTdProps, getCompoundExpandTdProps, getExpandedContentTdProps } =
     useExpansionPropHelpers({ ...args, columnKeys, numRenderedColumns });
   const { activeItemDerivedState, getActiveItemTrProps } = useActiveItemPropHelpers(args);
@@ -80,16 +80,6 @@ export const useTablePropHelpers = <
   const toolbarProps: PropHelpers['toolbarProps'] = {
     className: variant === 'compact' ? spacing.pt_0 : '',
     ...(isFilterEnabled && filterPropsForToolbar)
-  };
-
-  // TODO move this to a useSelectionPropHelpers when we move selection from lib-ui
-  const toolbarBulkSelectorProps: PropHelpers['toolbarBulkSelectorProps'] = {
-    onSelectAll: selectAll,
-    areAllSelected,
-    selectedRows: selectedItems,
-    paginationProps,
-    currentPageItems,
-    onSelectMultiple: selectMultiple
   };
 
   const tableProps: PropHelpers['tableProps'] = {
@@ -129,22 +119,12 @@ export const useTablePropHelpers = <
     };
   };
 
-  // TODO move this into a useSelectionPropHelpers and make it part of getTdProps once we move selection from lib-ui
-  const getSelectCheckboxTdProps: PropHelpers['getSelectCheckboxTdProps'] = ({ item, rowIndex }) => ({
-    select: {
-      rowIndex,
-      onSelect: (_event, isSelecting) => {
-        toggleItemSelected(item, isSelecting);
-      },
-      isSelected: isItemSelected(item)
-    }
-  });
-
   return {
     ...args,
     numColumnsBeforeData,
     numColumnsAfterData,
     numRenderedColumns,
+    selectionDerivedState,
     expansionDerivedState,
     activeItemDerivedState,
     propHelpers: {

--- a/packages/module/src/hooks/useTablePropHelpers.ts
+++ b/packages/module/src/hooks/useTablePropHelpers.ts
@@ -72,7 +72,10 @@ export const useTablePropHelpers = <
   const { filterPropsForToolbar, propsForFilterToolbar } = useFilterPropHelpers(args);
   const { getSortThProps } = useSortPropHelpers({ ...args, columnKeys });
   const { paginationProps, paginationToolbarItemProps } = usePaginationPropHelpers(args);
-  const { selectionDerivedState, toolbarBulkSelectorProps, getSelectCheckboxTdProps } = useSelectionPropHelpers(args); // TODO
+  const { selectionDerivedState, toolbarBulkSelectorProps, getSelectCheckboxTdProps } = useSelectionPropHelpers({
+    ...args,
+    paginationProps
+  });
   const { expansionDerivedState, getSingleExpandButtonTdProps, getCompoundExpandTdProps, getExpandedContentTdProps } =
     useExpansionPropHelpers({ ...args, columnKeys, numRenderedColumns });
   const { activeItemDerivedState, getActiveItemTrProps } = useActiveItemPropHelpers(args);

--- a/packages/module/src/hooks/useTablePropHelpers.ts
+++ b/packages/module/src/hooks/useTablePropHelpers.ts
@@ -11,14 +11,14 @@ import { handlePropagatedRowClick, objectKeys } from '../utils';
 
 /**
  * Returns derived state and prop helpers for all features. Used to make rendering the table components easier.
- * - Takes "source of truth" state and table-level derived state (derived either on the server or in getClientTableDerivedState)
+ * - Takes "source of truth" state and table-level derived state (derived either on the server or in useClientTableDerivedState)
  *   along with API data and additional args.
  * - Also triggers side-effects for some features to prevent invalid state.
  * - If you aren't using server-side filtering/sorting/pagination, call this via the shorthand hook useClientTableBatteries.
  * - If you are using server-side filtering/sorting/pagination, call this last after calling useTableState and fetching your API data.
  * @see useClientTableBatteries
  * @see useTableState
- * @see getClientTableDerivedState
+ * @see useClientTableDerivedState
  */
 export const useTablePropHelpers = <
   TItem,

--- a/packages/module/src/hooks/useTableState.ts
+++ b/packages/module/src/hooks/useTableState.ts
@@ -4,6 +4,7 @@ import { useSortState } from './sorting';
 import { usePaginationState } from './pagination';
 import { useActiveItemState } from './active-item';
 import { useExpansionState } from './expansion';
+import { useSelectionState } from './selection';
 
 /**
  * Provides the "source of truth" state for all table features.
@@ -40,6 +41,7 @@ export const useTableState = <
     ...args,
     persistTo: getPersistTo('pagination')
   });
+  const selectionState = useSelectionState(args);
   const expansionState = useExpansionState<TColumnKey, TPersistenceKeyPrefix>({
     ...args,
     persistTo: getPersistTo('expansion')
@@ -57,6 +59,7 @@ export const useTableState = <
     filterState,
     sortState,
     paginationState,
+    selectionState,
     expansionState,
     activeItemState,
     cacheKey

--- a/packages/module/src/tackle2-ui-legacy/components/ToolbarBulkSelector.tsx
+++ b/packages/module/src/tackle2-ui-legacy/components/ToolbarBulkSelector.tsx
@@ -128,6 +128,7 @@ export const ToolbarBulkSelector = <T,>({
             <MenuToggle
               ref={toggleRef}
               onClick={() => setIsOpen(!isOpen)}
+              aria-label="Bulk selection menu toggle"
               splitButtonOptions={{
                 items: [
                   <MenuToggleCheckbox

--- a/packages/module/src/tackle2-ui-legacy/components/ToolbarBulkSelector.tsx
+++ b/packages/module/src/tackle2-ui-legacy/components/ToolbarBulkSelector.tsx
@@ -16,8 +16,9 @@ import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-i
 export interface ToolbarBulkSelectorProps<T> {
   areAllSelected: boolean;
   areAllExpanded?: boolean;
-  onSelectAll: (flag: boolean) => void;
-  onExpandAll?: (flag: boolean) => void;
+  onSelectAll?: (flag?: boolean) => void;
+  onSelectNone: () => void;
+  onExpandAll?: (flag?: boolean) => void;
   selectedRows: T[];
   onSelectMultiple: (items: T[], isSelecting: boolean) => void;
   currentPageItems: T[];
@@ -29,6 +30,7 @@ export const ToolbarBulkSelector = <T,>({
   currentPageItems,
   areAllSelected,
   onSelectAll,
+  onSelectNone,
   onExpandAll,
   areAllExpanded,
   selectedRows,
@@ -65,8 +67,14 @@ export const ToolbarBulkSelector = <T,>({
     return state;
   };
   const handleSelectAll = (checked: boolean) => {
-    onSelectAll(!!checked);
+    onSelectAll?.(!!checked);
   };
+
+  const selectPage = () =>
+    onSelectMultiple(
+      currentPageItems.map((item: T) => item),
+      true
+    );
 
   // TODO support i18n / custom text for items below
 
@@ -74,6 +82,7 @@ export const ToolbarBulkSelector = <T,>({
     <DropdownItem
       onClick={() => {
         handleSelectAll(false);
+        setIsOpen(false);
       }}
       data-action="none"
       key="select-none"
@@ -83,10 +92,8 @@ export const ToolbarBulkSelector = <T,>({
     </DropdownItem>,
     <DropdownItem
       onClick={() => {
-        onSelectMultiple(
-          currentPageItems.map((item: T) => item),
-          true
-        );
+        selectPage();
+        setIsOpen(false);
       }}
       data-action="page"
       key="select-page"
@@ -94,16 +101,21 @@ export const ToolbarBulkSelector = <T,>({
     >
       Select page ({currentPageItems.length} items)
     </DropdownItem>,
-    <DropdownItem
-      onClick={() => {
-        handleSelectAll(true);
-      }}
-      data-action="all"
-      key="select-all"
-      component="button"
-    >
-      Select all ({paginationProps.itemCount})
-    </DropdownItem>
+    ...(onSelectAll
+      ? [
+          <DropdownItem
+            onClick={() => {
+              handleSelectAll(true);
+              setIsOpen(false);
+            }}
+            data-action="all"
+            key="select-all"
+            component="button"
+          >
+            Select all ({paginationProps.itemCount})
+          </DropdownItem>
+        ]
+      : [])
   ];
 
   return (
@@ -124,9 +136,13 @@ export const ToolbarBulkSelector = <T,>({
                     aria-label="Select all"
                     onChange={() => {
                       if (getBulkSelectState() !== false) {
-                        onSelectAll(false);
+                        onSelectNone();
                       } else {
-                        onSelectAll(true);
+                        if (onSelectAll) {
+                          onSelectAll(true);
+                        } else {
+                          selectPage();
+                        }
                       }
                     }}
                     isChecked={getBulkSelectState()}

--- a/packages/module/src/tackle2-ui-legacy/index.ts
+++ b/packages/module/src/tackle2-ui-legacy/index.ts
@@ -1,2 +1,3 @@
 export * from './components/FilterToolbar';
 export * from './components/TableControls';
+export * from './components/ToolbarBulkSelector';

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -1,19 +1,19 @@
 import { TableProps, TdProps, ThProps, TrProps } from '@patternfly/react-table';
 import {
   UseFilterStateArgs,
-  GetClientFilterDerivedStateArgs,
+  UseClientFilterDerivedStateArgs,
   UseFilterPropHelpersExternalArgs,
   FilterState
 } from './hooks/filtering';
 import {
-  GetClientSortDerivedStateArgs,
+  UseClientSortDerivedStateArgs,
   UseSortPropHelpersExternalArgs,
   SortState,
   UseSortStateArgs
 } from './hooks/sorting';
 import {
   UsePaginationStateArgs,
-  GetClientPaginationDerivedStateArgs,
+  UseClientPaginationDerivedStateArgs,
   UsePaginationPropHelpersExternalArgs,
   PaginationState
 } from './hooks/pagination';
@@ -185,19 +185,19 @@ export type TableState<
  * Table-level local derived state configuration arguments
  * - "Local derived state" refers to the results of client-side filtering/sorting/pagination. This is not used for server-paginated tables.
  * - Made up of the combined feature-level local derived state argument objects.
- * - Used by getClientTableDerivedState.
- *   - getClientTableDerivedState also requires the return values from useTableState.
+ * - Used by useClientTableDerivedState.
+ *   - useClientTableDerivedState also requires the return values from useTableState.
  * - Also used indirectly by the useClientTableBatteries shorthand hook.
  * - Requires state and API data in scope (or just API data if using useClientTableBatteries).
  */
-export type GetClientTableDerivedStateArgs<
+export type UseClientTableDerivedStateArgs<
   TItem,
   TColumnKey extends string,
   TSortableColumnKey extends TColumnKey,
   TFilterCategoryKey extends string = string
-> = GetClientFilterDerivedStateArgs<TItem, TFilterCategoryKey> &
-  GetClientSortDerivedStateArgs<TItem, TSortableColumnKey> &
-  GetClientPaginationDerivedStateArgs<TItem>;
+> = UseClientFilterDerivedStateArgs<TItem, TFilterCategoryKey> &
+  UseClientSortDerivedStateArgs<TItem, TSortableColumnKey> &
+  UseClientPaginationDerivedStateArgs<TItem>;
 // There is no ClientSelectionDerivedStateArgs type because selection derived state is always local and internal to useTablePropHelpers
 // There is no ClientExpansionDerivedStateArgs type because expansion derived state is always local and internal to useTablePropHelpers
 // There is no ClientActiveItemDerivedStateArgs type because active item derived state is always local and internal to useTablePropHelpers
@@ -207,7 +207,7 @@ export type GetClientTableDerivedStateArgs<
  * - "Derived state" here refers to the results of filtering/sorting/pagination performed either on the client or the server.
  * - Makes up part of the arguments object taken by useTablePropHelpers (UseTablePropHelpersArgs)
  * - Provided by either:
- *   - Return values of getClientTableDerivedState (client-side filtering/sorting/pagination)
+ *   - Return values of useClientTableDerivedState (client-side filtering/sorting/pagination)
  *   - The consumer directly (server-side filtering/sorting/pagination)
  * - Properties here are included in the `TableBatteries` object returned by useTablePropHelpers and useClientTableBatteries.
  * @see TableBatteries
@@ -229,7 +229,7 @@ export interface TableDerivedState<TItem> {
  * - Requires state and API data in scope
  * - Combines all args for useTableState with the return values of useTableState, args used only for rendering, and args derived from either:
  *   - Server-side filtering/sorting/pagination provided by the consumer
- *   - getClientTableDerivedState (client-side filtering/sorting/pagination)
+ *   - useClientTableDerivedState (client-side filtering/sorting/pagination)
  * - Properties here are included in the `TableBatteries` object returned by useTablePropHelpers and useClientTableBatteries.
  * @see TableBatteries
  */
@@ -267,7 +267,7 @@ export type UseTablePropHelpersArgs<
   };
 
 /**
- * Table controls object
+ * Table batteries object
  * - The object used for rendering. Includes everything you need to return JSX for your table.
  * - Returned by useTablePropHelpers and useClientTableBatteries
  * - Includes all args and return values from useTableState and useTablePropHelpers (configuration, state, derived state and propHelpers).
@@ -374,7 +374,7 @@ export type TableBatteries<
 /**
  * Combined configuration arguments for client-paginated tables
  * - Used by useClientTableBatteries shorthand hook
- * - Combines args for useTableState, getClientTableDerivedState and useTablePropHelpers, omitting args for any of these that come from return values of the others.
+ * - Combines args for useTableState, useClientTableDerivedState and useTablePropHelpers, omitting args for any of these that come from return values of the others.
  */
 export type UseClientTableBatteriesArgs<
   TItem,
@@ -384,7 +384,7 @@ export type UseClientTableBatteriesArgs<
   TPersistenceKeyPrefix extends string = string
 > = UseTableStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix> &
   Omit<
-    GetClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey> &
+    UseClientTableDerivedStateArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey> &
       UseTablePropHelpersArgs<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey>,
     | keyof TableDerivedState<TItem>
     | keyof TableState<TItem, TColumnKey, TSortableColumnKey, TFilterCategoryKey, TPersistenceKeyPrefix>

--- a/packages/module/src/types.ts
+++ b/packages/module/src/types.ts
@@ -53,6 +53,8 @@ export type TableFeature = 'filter' | 'sort' | 'pagination' | 'selection' | 'exp
  */
 export type PersistTarget = 'state' | 'urlParams' | 'localStorage' | 'sessionStorage';
 
+export type ItemId = string | number;
+
 /**
  * Common persistence-specific args
  * - Makes up part of the arguments object taken by useTableState (UseTableStateArgs)


### PR DESCRIPTION
Addresses some tech debt that has been bugging me for a while. The selection feature is now fully integrated alongside the other features and no longer depends on the migtools lib-ui useSelectionState (which will be retired). The selection feature handles the behavior it used to plus non-selectable items, shift+click to select multiple items, and logic related to bulk select (specifically around the differences between client and server tables -- we can't "select all" on a server-driven table because we don't know all the item ids).

Also implements the Selection feature example in docs in order to test drive these changes.

One thing to note here is that I've also renamed all of the `get*DerivedState` functions to `use*DerivedState` since we needed to call a `useMemo` in `useSelectionDerivedState` which means it needed hook naming. The other derived state hooks aren't calling any hooks currently, but consistent naming made sense to me and now we can introduce future memoization or whatever other hook usage in them as necessary without renaming stuff.