### PR TITLE
Fix memoization dependencies in useTrWithBatteries

### DIFF
--- a/packages/module/src/components/useTrWithBatteries.tsx
+++ b/packages/module/src/components/useTrWithBatteries.tsx
@@ -63,9 +63,6 @@ export const useTrWithBatteries = <
           const { isHeaderRow, onRowClick, builtInControls = true, children, ...otherProps } = props;
           const { item, rowIndex } = props as Partial<TrWithBatteriesBodyRowProps<TItem>>;
 
-          // eslint-disable-next-line no-console
-          console.log({ isHeaderRow, item, numColumnsBeforeData, numColumnsAfterData });
-
           return (
             <Tr
               {...propHelpers.getTrProps({ item, onRowClick })}
@@ -105,7 +102,14 @@ export const useTrWithBatteries = <
           );
         }
       ),
-    [activeItem.isEnabled, activeItem.activeItemId]
+    [
+      activeItem.isEnabled,
+      activeItem.activeItemId,
+      selection.isEnabled,
+      selection.selectedItemIds,
+      expansion.isEnabled,
+      expansion.expandedCells
+    ]
   );
   TrWithBatteries.displayName = 'TrWithBatteries';
   return TrWithBatteries;


### PR DESCRIPTION
Here's an issue caused by the tech debt described in #6. I neglected to include the selection and expansion state in the `useDeepCompareMemo` dependency array for `useTrWithBatteries`. When selection state changed, the reference to the `Tr` component being rendered was not updated and was using an out of date copy of the batteries object, so the checkbox didn't check even though the item was selected in state.

cc @gitdallas 